### PR TITLE
Added iOS 11.0 restriction to Dictionary+AsJSONSerializedData

### DIFF
--- a/Sources/UtilityBeltNetworking/Extensions/Dictionary+AsJSONSerializedData.swift
+++ b/Sources/UtilityBeltNetworking/Extensions/Dictionary+AsJSONSerializedData.swift
@@ -4,7 +4,7 @@ import Foundation
 
 extension Dictionary {
     func asJSONSerializedData() throws -> Data {
-        if #available(OSX 10.13, *) {
+        if #available(iOS 11.0, OSX 10.13, *) {
             return try JSONSerialization.data(withJSONObject: self, options: .sortedKeys)
         } else {
             return try JSONSerialization.data(withJSONObject: self, options: [])


### PR DESCRIPTION
**Description**
Added this check in order to not have an error if the target is iOS 10. Would rather does this simple check than drop 10.0 support unnecessarily.
