### PR TITLE
Added explicit versioning to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,12 @@ import PackageDescription
 
 let package = Package(
     name: "UtilityBelt",
+    platforms: [
+        .iOS(.v10),
+        .macOS(.v10_10),
+        .tvOS(.v9),
+        .watchOS(.v2),
+    ],
     products: [
         .library(name: "UtilityBelt", targets: ["UtilityBeltNetworking"]),
         .library(name: "UtilityBeltNetworking", targets: ["UtilityBeltNetworking"]),
@@ -22,5 +28,8 @@ let package = Package(
                 .target(name: "UtilityBeltNetworking"),
             ]
         ),
+    ],
+    swiftLanguageVersions: [
+        .v5,
     ]
 )

--- a/Sources/UtilityBeltNetworking/Extensions/Dictionary+AsJSONSerializedData.swift
+++ b/Sources/UtilityBeltNetworking/Extensions/Dictionary+AsJSONSerializedData.swift
@@ -4,7 +4,7 @@ import Foundation
 
 extension Dictionary {
     func asJSONSerializedData() throws -> Data {
-        if #available(iOS 11.0, OSX 10.13, *) {
+        if #available(iOS 11.0, OSX 10.13, watchOS 4.0, tvOS 11.0, *) {
             return try JSONSerialization.data(withJSONObject: self, options: .sortedKeys)
         } else {
             return try JSONSerialization.data(withJSONObject: self, options: [])

--- a/Tests/UtilityBeltNetworkingTests/Tests/HTTPStatusCodeTests.swift
+++ b/Tests/UtilityBeltNetworkingTests/Tests/HTTPStatusCodeTests.swift
@@ -1,6 +1,7 @@
 // Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 @testable import UtilityBeltNetworking
+
 import XCTest
 
 final class HTTPStatusCodeTests: XCTestCase {


### PR DESCRIPTION
**Description**
While not required to do so, I added explicit platform support to UtilityBelt. The default (by not including these) is either _lower_ or equal to the versions I have listed.

In addition, there is no option for swift language version `5.1` and no need to do so. We should be specifying v5 and `5.0` anywhere it takes it.
