### PR TITLE
Fixed typo in Refresh HTTPHeader

### DIFF
--- a/Sources/UtilityBeltNetworking/Enums/HTTPHeader.swift
+++ b/Sources/UtilityBeltNetworking/Enums/HTTPHeader.swift
@@ -174,7 +174,7 @@ public enum HTTPHeader: String {
     case proxyAuthenticate = "Proxy-Authenticate"
 
     ///
-    case refresh = "Reresh"
+    case refresh = "Refresh"
 
     /// If an entity is temporarily unavailable, this instructs the client to try again later.
     /// Value could be a specified period of time (in seconds) or a HTTP-date.


### PR DESCRIPTION
**Description**
`Reresh` -> `Refresh`
