### PR TITLE
Fixed OSLog import

### DIFF
--- a/Sources/Sham/MockService.swift
+++ b/Sources/Sham/MockService.swift
@@ -1,7 +1,7 @@
 // Copyright © 2019 SpotHero, Inc. All rights reserved.
 
 import Foundation
-import OSLog
+import os
 import UtilityBeltNetworking
 
 /// A service which contains stub requests and stub responses for use with the MockURLProtocol.


### PR DESCRIPTION
**Description**
`OSLog` is a valid import, but `os` is the cross-platform framework I should have been using.

[Documentation](https://developer.apple.com/documentation/os?language=objc)
