### PR TITLE
IOS-1546: Implemented Keychain boilerplate with failing tests

### DIFF
--- a/Sources/UtilityBeltKeychain/Models/Keychain.swift
+++ b/Sources/UtilityBeltKeychain/Models/Keychain.swift
@@ -1,0 +1,66 @@
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+/// A wrapper around Keychain Item configuration to simplify usage.
+public final class Keychain {
+    // MARK: - Methods
+    
+    // MARK: Initializers
+    
+    /// Initializes a Generic Password Keychain.
+    /// - Parameters:
+    ///   - service: The service associated with this item.
+    ///   - accessGroup: The access group associated with this item.
+    public init(service: String, accessGroup: String? = nil) {
+    }
+    
+    /// Initializes an Internet Password Keychain.
+    /// - Parameters:
+    ///   - server: The domain name or IP address associated with this item.
+    ///   - protocol: The internet protocol associated with this item.
+    ///   - authenticationType: The authentication type associated with this item.
+    ///   - path: The path component of the URL associated with this item.
+    ///   - port: The port number associated with this item.
+    ///   - securityDomain: The security domain associated with this item.
+    ///   - accessGroup: The access group associated with this item.
+    public init(server: String,
+                protocol: KeychainInternetProtocol = .https,
+                authenticationType: KeychainAuthenticationType = .default,
+                path: String? = nil,
+                port: Int? = nil,
+                securityDomain: String? = nil,
+                accessGroup: String? = nil) {
+    }
+    
+    // MARK: Key Access
+    
+    /// Sets a String value for a given account in the keychain.
+    /// - Parameters:
+    ///   - value: The data to set in the keychain.
+    ///   - account: The account to set the data for.
+    public func setValue(_ value: String, for account: String) throws {
+    }
+    
+    /// Sets a Data value for a given account in the keychain.
+    /// - Parameters:
+    ///   - value: The data to set in the keychain.
+    ///   - account: The account to set the data for.
+    public func setValue(_ value: Data, for account: String) throws {
+    }
+    
+    /// Gets a Data value for a given account in the keychain.
+    /// - Parameter account: The account to get the value from.
+    public func getValue(for account: String) throws -> Data? {
+        return nil
+    }
+    
+    /// Removes a value for a given account in the keychain.
+    /// - Parameter account: The account to remove the value from.
+    public func removeValue(for account: String) throws {
+    }
+
+    /// Removes all values from the Keychain.
+    public func removeAllValues() throws {
+    }
+}

--- a/UtilityBeltTests/UtilityBeltKeychainTests/Extensions/XCTestCase+MeasureAndCatch.swift
+++ b/UtilityBeltTests/UtilityBeltKeychainTests/Extensions/XCTestCase+MeasureAndCatch.swift
@@ -1,0 +1,18 @@
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
+
+import Foundation
+import XCTest
+
+extension XCTestCase {
+    func measureAndCatch(file: StaticString = #file,
+                         line: UInt = #line,
+                         block: () throws -> Void) {
+        measure {
+            do {
+                try block()
+            } catch {
+                XCTFail(error.localizedDescription, file: file, line: line)
+            }
+        }
+    }
+}

--- a/UtilityBeltTests/UtilityBeltKeychainTests/Protocols/PasswordKeychainTesting.swift
+++ b/UtilityBeltTests/UtilityBeltKeychainTests/Protocols/PasswordKeychainTesting.swift
@@ -1,0 +1,79 @@
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
+
+@testable import UtilityBeltKeychain
+import XCTest
+
+protocol PasswordKeychainTesting: XCTestCase {
+    var keychain: Keychain { get }
+    var firstPassword: String { get }
+    var firstAccount: String { get }
+    var secondPassword: String { get }
+    var secondAccount: String { get }
+}
+
+extension PasswordKeychainTesting {
+    func cleanUp(file: StaticString = #file, line: UInt = #line) {
+        do {
+            try self.keychain.removeAllValues()
+        } catch {
+            XCTFail(error.localizedDescription, file: file, line: line)
+        }
+    }
+
+    func savePassword(file: StaticString = #file, line: UInt = #line) {
+        self.measureAndCatch(file: file, line: line) {
+            try self.keychain.setValue(self.firstPassword, for: self.firstAccount)
+        }
+    }
+
+    func readPassword(file: StaticString = #file, line: UInt = #line) {
+        self.measureAndCatch(file: file, line: line) {
+            try self.keychain.setValue(self.firstPassword, for: self.firstAccount)
+            
+            guard let passwordData = try keychain.getValue(for: self.firstAccount) else {
+                XCTFail("Password data is nil.")
+                return
+            }
+            
+            let password = String(data: passwordData, encoding: .utf8)
+        
+            XCTAssertEqual(self.firstPassword, password, file: file, line: line)
+        }
+    }
+
+    func updatePassword(file: StaticString = #file, line: UInt = #line) {
+        self.measureAndCatch(file: file, line: line) {
+            try self.keychain.setValue(self.firstPassword, for: self.firstAccount)
+            try self.keychain.setValue(self.secondPassword, for: self.firstAccount)
+            
+            guard let passwordData = try keychain.getValue(for: self.firstAccount) else {
+                XCTFail("Password data is nil.")
+                return
+            }
+            
+            let password = String(data: passwordData, encoding: .utf8)
+            
+            XCTAssertEqual(self.secondPassword, password, file: file, line: line)
+        }
+    }
+
+    func deletePassword(file: StaticString = #file, line: UInt = #line) {
+        self.measureAndCatch(file: file, line: line) {
+            try self.keychain.setValue(self.firstPassword, for: self.firstAccount)
+            try self.keychain.removeValue(for: self.firstAccount)
+            
+            XCTAssertNil(try self.keychain.getValue(for: self.firstAccount), file: file, line: line)
+        }
+    }
+
+    func deleteAllPasswords(file: StaticString = #file, line: UInt = #line) {
+        self.measureAndCatch(file: file, line: line) {
+            try self.keychain.setValue(self.firstPassword, for: self.firstAccount)
+            try self.keychain.setValue(self.secondPassword, for: self.secondAccount)
+            try self.keychain.removeAllValues()
+            
+            XCTAssertNil(try self.keychain.getValue(for: self.firstAccount), file: file, line: line)
+            XCTAssertNil(try self.keychain.getValue(for: self.secondAccount), file: file, line: line)
+        }
+    }
+}

--- a/UtilityBeltTests/UtilityBeltKeychainTests/TestCases/GenericPasswordTests.swift
+++ b/UtilityBeltTests/UtilityBeltKeychainTests/TestCases/GenericPasswordTests.swift
@@ -1,0 +1,40 @@
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
+
+@testable import UtilityBeltKeychain
+import XCTest
+
+class GenericPasswordTests: XCTestCase, PasswordKeychainTesting {
+    var keychain = Keychain(service: "MyService")
+    
+    var firstPassword = "pwd_1234"
+    var firstAccount = "genericPassword"
+    
+    var secondPassword = "pwd_1235"
+    var secondAccount = "genericPassword2"
+
+    override func tearDown() {
+        self.cleanUp()
+
+        super.tearDown()
+    }
+
+    func testSaveGenericPassword() {
+        self.savePassword()
+    }
+
+    func testReadGenericPassword() {
+        self.readPassword()
+    }
+
+    func testUpdateGenericPassword() {
+        self.updatePassword()
+    }
+
+    func testDeleteGenericPassword() {
+        self.deletePassword()
+    }
+
+    func testDeleteAllGenericPasswords() {
+        self.deleteAllPasswords()
+    }
+}

--- a/UtilityBeltTests/UtilityBeltKeychainTests/TestCases/InternetPasswordTests.swift
+++ b/UtilityBeltTests/UtilityBeltKeychainTests/TestCases/InternetPasswordTests.swift
@@ -1,0 +1,45 @@
+// Copyright © 2019 SpotHero, Inc. All rights reserved.
+
+@testable import UtilityBeltKeychain
+import XCTest
+
+class InternetPasswordTests: XCTestCase, PasswordKeychainTesting {
+    var keychain = Keychain(server: "someServer",
+                            protocol: .https,
+                            authenticationType: .httpBasic,
+                            path: "somePath",
+                            port: 8080,
+                            securityDomain: "someDomain")
+    
+    var firstPassword = "pwd_1234"
+    var firstAccount = "internetPassword"
+    
+    var secondPassword = "pwd_1235"
+    var secondAccount = "internetPassword2"
+
+    override func tearDown() {
+        self.cleanUp()
+
+        super.tearDown()
+    }
+
+    func testSaveInternetPassword() {
+        self.savePassword()
+    }
+
+    func testReadInternetPassword() {
+        self.readPassword()
+    }
+
+    func testUpdateInternetPassword() {
+        self.updatePassword()
+    }
+
+    func testDeleteInternetPassword() {
+        self.deletePassword()
+    }
+
+    func testDeleteAllInternetPasswords() {
+        self.deleteAllPasswords()
+    }
+}

--- a/UtilityBeltTests/UtilityBeltKeychainTests/TestCases/UtilityBeltKeychainTests.swift
+++ b/UtilityBeltTests/UtilityBeltKeychainTests/TestCases/UtilityBeltKeychainTests.swift
@@ -1,5 +1,0 @@
-// Copyright © 2019 SpotHero, Inc. All rights reserved.
-
-import XCTest
-
-class UtilityBeltKeychainTests: XCTestCase {}

--- a/UtilityBeltTests/UtilityBeltTests.xcodeproj/project.pbxproj
+++ b/UtilityBeltTests/UtilityBeltTests.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3451094523A82408006E98DB /* GenericPasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3451094323A82408006E98DB /* GenericPasswordTests.swift */; };
+		3451094623A82408006E98DB /* InternetPasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3451094423A82408006E98DB /* InternetPasswordTests.swift */; };
+		3451094B23A8241F006E98DB /* XCTestCase+MeasureAndCatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3451094A23A8241F006E98DB /* XCTestCase+MeasureAndCatch.swift */; };
+		3451094E23A82426006E98DB /* PasswordKeychainTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3451094D23A82426006E98DB /* PasswordKeychainTesting.swift */; };
 		345796EE2391DFFF0009C62D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345796ED2391DFFF0009C62D /* AppDelegate.swift */; };
 		345796F02391DFFF0009C62D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345796EF2391DFFF0009C62D /* SceneDelegate.swift */; };
 		345796F42391DFFF0009C62D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345796F32391DFFF0009C62D /* ContentView.swift */; };
@@ -15,7 +19,7 @@
 		345796FC2391E0000009C62D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 345796FA2391E0000009C62D /* LaunchScreen.storyboard */; };
 		34BE19F02391FC1000ED5FC1 /* UtilityBeltDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BE19EF2391FC1000ED5FC1 /* UtilityBeltDataTests.swift */; };
 		34BE19F82391FC8F00ED5FC1 /* UtilityBeltData in Frameworks */ = {isa = PBXBuildFile; productRef = 34BE19F72391FC8F00ED5FC1 /* UtilityBeltData */; };
-		34D6EBDD2399AC3E005429FC /* UtilityBeltKeychainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D6EBDC2399AC3E005429FC /* UtilityBeltKeychainTests.swift */; };
+		34E13B5923A8252900E7EFC5 /* UtilityBeltKeychain in Frameworks */ = {isa = PBXBuildFile; productRef = 34E13B5823A8252900E7EFC5 /* UtilityBeltKeychain */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -36,6 +40,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3451094323A82408006E98DB /* GenericPasswordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenericPasswordTests.swift; sourceTree = "<group>"; };
+		3451094423A82408006E98DB /* InternetPasswordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternetPasswordTests.swift; sourceTree = "<group>"; };
+		3451094A23A8241F006E98DB /* XCTestCase+MeasureAndCatch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MeasureAndCatch.swift"; sourceTree = "<group>"; };
+		3451094D23A82426006E98DB /* PasswordKeychainTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordKeychainTesting.swift; sourceTree = "<group>"; };
 		345796EB2391DFFF0009C62D /* UtilityBeltDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = UtilityBeltDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		345796ED2391DFFF0009C62D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		345796EF2391DFFF0009C62D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -48,7 +56,6 @@
 		34BE19EF2391FC1000ED5FC1 /* UtilityBeltDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityBeltDataTests.swift; sourceTree = "<group>"; };
 		34BE19F12391FC1000ED5FC1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		34D6EBDA2399AC3E005429FC /* UtilityBeltKeychainTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UtilityBeltKeychainTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		34D6EBDC2399AC3E005429FC /* UtilityBeltKeychainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityBeltKeychainTests.swift; sourceTree = "<group>"; };
 		34D6EBDE2399AC3E005429FC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -72,12 +79,29 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				34E13B5923A8252900E7EFC5 /* UtilityBeltKeychain in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3451094923A8241F006E98DB /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				3451094A23A8241F006E98DB /* XCTestCase+MeasureAndCatch.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		3451094C23A82426006E98DB /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				3451094D23A82426006E98DB /* PasswordKeychainTesting.swift */,
+			);
+			path = Protocols;
+			sourceTree = "<group>";
+		};
 		345796A62391DF280009C62D = {
 			isa = PBXGroup;
 			children = (
@@ -173,6 +197,8 @@
 			isa = PBXGroup;
 			children = (
 				34D6EBE52399AC5D005429FC /* Config */,
+				3451094923A8241F006E98DB /* Extensions */,
+				3451094C23A82426006E98DB /* Protocols */,
 				34D6EBE62399AC60005429FC /* TestCases */,
 			);
 			path = UtilityBeltKeychainTests;
@@ -189,7 +215,8 @@
 		34D6EBE62399AC60005429FC /* TestCases */ = {
 			isa = PBXGroup;
 			children = (
-				34D6EBDC2399AC3E005429FC /* UtilityBeltKeychainTests.swift */,
+				3451094323A82408006E98DB /* GenericPasswordTests.swift */,
+				3451094423A82408006E98DB /* InternetPasswordTests.swift */,
 			);
 			path = TestCases;
 			sourceTree = "<group>";
@@ -265,6 +292,9 @@
 				34D6EBE02399AC3E005429FC /* PBXTargetDependency */,
 			);
 			name = UtilityBeltKeychainTests;
+			packageProductDependencies = (
+				34E13B5823A8252900E7EFC5 /* UtilityBeltKeychain */,
+			);
 			productName = UtilityBeltKeychainTests;
 			productReference = 34D6EBDA2399AC3E005429FC /* UtilityBeltKeychainTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -362,7 +392,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				34D6EBDD2399AC3E005429FC /* UtilityBeltKeychainTests.swift in Sources */,
+				3451094523A82408006E98DB /* GenericPasswordTests.swift in Sources */,
+				3451094E23A82426006E98DB /* PasswordKeychainTesting.swift in Sources */,
+				3451094623A82408006E98DB /* InternetPasswordTests.swift in Sources */,
+				3451094B23A8241F006E98DB /* XCTestCase+MeasureAndCatch.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -672,6 +705,10 @@
 		34BE19F72391FC8F00ED5FC1 /* UtilityBeltData */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = UtilityBeltData;
+		};
+		34E13B5823A8252900E7EFC5 /* UtilityBeltKeychain */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = UtilityBeltKeychain;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
**JIRA URL**
https://spothero.atlassian.net/browse/IOS-1546

**Description**
- Added `UtilityBeltKeychain` to the `UtilityBeltKeychainTests` target.
- Implemented a boilerplate `Keychain` class to implement failing tests upon.
- Added `GenericPassword` and `InternetPassword` tests, backed by the `PasswordTesting` protocol (which will help with testing both types).
