### PR TITLE
Updated with Zinc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,9 @@
+# This file is sourced from https://github.com/spothero/Shared-iOS
+
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 # Source: https://blog.github.com/2017-07-06-introducing-code-owners/
 # Source: https://help.github.com/articles/about-codeowners/
 
 # These owners will be the default owners for everything in the repo.
-@spothero/ios
+* @spothero/ios

--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,9 @@ fastlane/test_output
 fastlane/[Pp]rovisioning
 fastlane/report.xml
 fastlane/[Bb]uild
+fastlane/[Oo]utput
 fastlane/DerivedData
+fastlane/derived_data
 fastlane/screenshots
 fastlane/[Pp]review.html
 

--- a/.swiftformat
+++ b/.swiftformat
@@ -42,5 +42,7 @@
 --exclude .build
 --exclude .swiftpm
 --exclude Package.swift
+--exclude */Package.swift
 --exclude Tests/LinuxMain.swift
 --exclude "Tests/*/XCTestManifests.swift"
+--exclude "**/*/*+CoreDataProperties.swift"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,12 +1,13 @@
 # Updated for v0.34.0
 
 disabled_rules:
-  # We run the swift_combined_lint_run_script.sh which handles TODO/FIXME/WARN/WARNING independently, so we want to disable this.
+  - number_separator # Underscores should be used as thousand separator in large decimal numbers.
   - todo # TODOs and FIXMEs should be resolved.
+  - trailing_closure # Trailing closure syntax should be used whenever possible.
 
 opt_in_rules:
   - anyobject_protocol # Prefer using AnyObject over class for class-only protocols.
-  - array_init #Prefer using Array(seq) over seq.map { $0 } to convert a sequence into an Array.
+  - array_init # Prefer using Array(seq) over seq.map { $0 } to convert a sequence into an Array.
   - attributes # Attributes should be on their own lines in functions and types, but on the same line as variables and imports.
   - closure_end_indentation # Closure end should have the same indentation as the line that started it.
   - closure_spacing # Closure expressions should have a single space inside each brace.
@@ -23,6 +24,7 @@ opt_in_rules:
   - first_where # "Prefer using `.first(where:)` over `.filter { }.first` in collections.
   - force_unwrapping # Force unwrapping should be avoided.
   - function_default_parameter_at_end # Prefer to locate parameters with defaults toward the end of the parameter list.
+  - function_parameter_count # Number of function parameters should be low.
   - identical_operands # Comparing two identical operands is likely a mistake.
   - implicitly_unwrapped_optional # Implicitly unwrapped optionals should be avoided when possible.
   - joined_default_parameter # Discouraged explicit usage of the default separator.
@@ -62,7 +64,8 @@ cyclomatic_complexity: # Complexity of function bodies should be limited.
   ignores_case_statements: true # ignores switch statements
 empty_count: warning # Prefer checking `isEmpty` over comparing `count` to zero.
 file_header:
-  required_pattern: "// Copyright © 2019 SpotHero, Inc. All rights reserved."
+  required_pattern: |
+    \/\/  Copyright © \d{4} SpotHero, Inc\. All rights reserved\.
 file_name: # File name should match a type or extension declared in the file (if any).
   excluded: ["Enums.swift"]
 file_length: # Files should not span too many lines.
@@ -73,6 +76,9 @@ force_try: warning # Force tries should be avoided.
 function_body_length: # Functions' bodies should not span too many lines.
   warning: 100
   error: 200
+function_parameter_count:
+  warning: 7
+  error: 9
 identifier_name: # Identifier names should only contain alphanumeric characters and start with a lowercase character or should only contain capital letters.
   allowed_symbols:
     - _

--- a/.zinc/rubocop.yml
+++ b/.zinc/rubocop.yml
@@ -11,6 +11,10 @@ AllCops:
     - '**/*.rb'
     - '**/*.podspec'
 
+# Matches SwiftLint line length
+Layout/LineLength:
+  Max: 150
+
 # ABC size = Assignment Branch Condition size, kind of like cyclomatic complexity
 # Fastlane as a whole kind of blows up when this is enabled, so we're turning it off (at least for now)
 Metrics/AbcSize:
@@ -19,10 +23,6 @@ Metrics/AbcSize:
 # We don't care about block length right now
 Metrics/BlockLength:
   Enabled: false
-
-# Matches SwiftLint line length
-Metrics/LineLength:
-  Max: 150
 
 # We don't care about method length right now
 Metrics/MethodLength:


### PR DESCRIPTION
**Description**
- Ran `mint run zinc`, fixed `.swiftlint.yml` file to include `missing_docs` still.