### PR TITLE
Made defaultEncoding(for:) public

### DIFF
--- a/Sources/UtilityBeltNetworking/Enums/ParameterEncoding.swift
+++ b/Sources/UtilityBeltNetworking/Enums/ParameterEncoding.swift
@@ -8,7 +8,7 @@ public enum ParameterEncoding {
     case queryString
 
     /// Returns the default encoding for a given HTTP method.
-    static func defaultEncoding(for method: HTTPMethod) -> ParameterEncoding {
+    public static func defaultEncoding(for method: HTTPMethod) -> ParameterEncoding {
         switch method {
         case .delete, .get, .head:
             return .queryString

--- a/UtilityBelt.podspec
+++ b/UtilityBelt.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   # Root Specification
   spec.name = 'UtilityBelt'
-  spec.version = '0.4.2'
+  spec.version = '0.4.3'
 
   spec.author   = { 'SpotHero' => 'ios@spothero.com' }
   spec.homepage = 'https://github.com/spothero/UtilityBelt-iOS'


### PR DESCRIPTION
**Description**
Needed this method to be public for upcoming `SpotHeroAPI` changes. It was a mistake that it was internal.
