### PR TITLE
IOS-1940: Implemented headers in HTTPClient.request methods

### DIFF
--- a/Sources/UtilityBeltNetworking/Extensions/URLRequest+HTTPHeader.swift
+++ b/Sources/UtilityBeltNetworking/Extensions/URLRequest+HTTPHeader.swift
@@ -1,9 +1,0 @@
-// Copyright © 2020 SpotHero, Inc. All rights reserved.
-
-import Foundation
-
-extension URLRequest {
-    mutating func setValue(_ value: String?, forHTTPHeaderField field: HTTPHeader) {
-        self.setValue(value, forHTTPHeaderField: field.rawValue)
-    }
-}

--- a/Sources/UtilityBeltNetworking/Extensions/URLRequest+SetHeaders.swift
+++ b/Sources/UtilityBeltNetworking/Extensions/URLRequest+SetHeaders.swift
@@ -1,0 +1,25 @@
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+extension URLRequest {
+    /// Set a value for the header field.
+    /// - Parameters:
+    ///   - value: The new value for the header field. Any existing value for the field is replaced by the new value.
+    ///   - field: The `HTTPHeader` enum value of the header field to set.
+    mutating func setValue(_ value: String?, forHTTPHeaderField field: HTTPHeader) {
+        self.setValue(value, forHTTPHeaderField: field.rawValue)
+    }
+    
+    /// Sets values for header fields in a given dictionary.
+    /// - Parameter headers: The dictionary of HTTP headers to set.
+    mutating func setHeaders(_ headers: HTTPHeaderDictionaryConvertible?) {
+        guard let headers = headers?.asHeaderDictionary() else {
+            return
+        }
+        
+        for header in headers {
+            self.setValue(header.value, forHTTPHeaderField: header.key.rawValue)
+        }
+    }
+}

--- a/Sources/UtilityBeltNetworking/Extensions/URLRequest+SetHeaders.swift
+++ b/Sources/UtilityBeltNetworking/Extensions/URLRequest+SetHeaders.swift
@@ -10,14 +10,14 @@ extension URLRequest {
     mutating func setValue(_ value: String?, forHTTPHeaderField field: HTTPHeader) {
         self.setValue(value, forHTTPHeaderField: field.rawValue)
     }
-    
+
     /// Sets values for header fields in a given dictionary.
     /// - Parameter headers: The dictionary of HTTP headers to set.
     mutating func setHeaders(_ headers: HTTPHeaderDictionaryConvertible?) {
         guard let headers = headers?.asHeaderDictionary() else {
             return
         }
-        
+
         for header in headers {
             self.setValue(header.value, forHTTPHeaderField: header.key.rawValue)
         }

--- a/Sources/UtilityBeltNetworking/HTTPClient.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient.swift
@@ -11,27 +11,27 @@ public typealias DecodableTaskCompletion<T: Decodable> = (DataResponse<T, Error>
 /// A lightweight HTTP Client that supports data tasks
 public class HTTPClient {
     // MARK: - Shared Instance
-    
+
     /// The shared HTTP Client instance.
     public static let shared = HTTPClient()
-    
+
     // MARK: - Properties
-    
+
     /// The URLSession that is used for all requests.
     private let session: URLSession
-    
+
     // MARK: - Methods
-    
+
     // MARK: Initializers
-    
+
     /// Initializes a new HTTPClient with a given URLSession.
     /// - Parameter session: The URLSession to use for all requests.
     public init(session: URLSession = .shared) {
         self.session = session
     }
-    
+
     // MARK: Request
-    
+
     /// Creates and sends a request, fetching raw data from an endpoint.
     /// Returns a `URLSessionTask`, which allows for cancellation and retries.
     /// - Parameter url: The URL for the request. Accepts a URL or a String.
@@ -39,7 +39,7 @@ public class HTTPClient {
     /// - Parameter parameters: The dictionary of parameters to send in the query string or HTTP body.
     /// - Parameter headers: The HTTP headers to be with the request.
     /// - Parameter encoding: The parameter encoding method. If nil, uses default for HTTP method.
-    /// - Parameter completion: The completion block to call when the request is completed. 
+    /// - Parameter completion: The completion block to call when the request is completed.
     @discardableResult
     public func request(_ url: URLConvertible,
                         method: HTTPMethod,
@@ -52,16 +52,17 @@ public class HTTPClient {
             method: method,
             parameters: parameters,
             headers: headers,
-            encoding: encoding) else {
-                completion?(.failure(UBNetworkError.unexpectedError))
-                return nil
+            encoding: encoding
+        ) else {
+            completion?(.failure(UBNetworkError.unexpectedError))
+            return nil
         }
-        
+
         let task = self.session.dataTask(with: request) { data, urlResponse, error in
             // Convert the URLResponse into an HTTPURLResponse object.
             // If it cannot be converted, use the undefined HTTPURLResponse object
             let httpResponse = urlResponse as? HTTPURLResponse
-            
+
             // Create a result object for improved handling of the response
             let result: Result<Data, Error> = {
                 if let data = data {
@@ -72,22 +73,22 @@ public class HTTPClient {
                     return .failure(UBNetworkError.unexpectedError)
                 }
             }()
-            
+
             // Create the DataResponse object containing all necessary information from the response
             let dataResponse = DataResponse(request: request,
                                             response: httpResponse,
                                             data: data,
                                             result: result)
-            
+
             // Fire the completion!
             completion?(dataResponse)
         }
-        
+
         task.resume()
-        
+
         return task
     }
-    
+
     /// Creates and sends a request, fetching raw data from an endpoint that is decoded into a Decodable object.
     /// Returns a `URLSessionTask`, which allows for cancellation and retries.
     /// - Parameter url: The URL for the request. Accepts a URL or a String.
@@ -110,36 +111,37 @@ public class HTTPClient {
             method: method,
             parameters: parameters,
             headers: headers,
-            encoding: encoding) { dataResponse in
-                // TODO: Check the response.mimeType and ensure it is application/json, which is required for decoding
-                
-                // Create a result object for improved handling of the response
-                let result: Result<T, Error> = {
-                    switch dataResponse.result {
-                    case let .success(data):
-                        do {
-                            let decodedObject = try decoder.decode(T.self, from: data)
-                            return .success(decodedObject)
-                        } catch let error {
+            encoding: encoding
+        ) { dataResponse in
+            // TODO: Check the response.mimeType and ensure it is application/json, which is required for decoding
+
+            // Create a result object for improved handling of the response
+            let result: Result<T, Error> = {
+                switch dataResponse.result {
+                case let .success(data):
+                    do {
+                        let decodedObject = try decoder.decode(T.self, from: data)
+                        return .success(decodedObject)
+                    } catch {
 //                            return .failure(UBNetworkError.unableToDecode(String(describing: T.self)))
-                            return .failure(error)
-                        }
-                    case let .failure(error):
                         return .failure(error)
                     }
-                }()
-                
-                // Create the DataResponse object containing all necessary information from the response
-                let response = DataResponse(request: dataResponse.request,
-                                            response: dataResponse.response,
-                                            data: dataResponse.data,
-                                            result: result)
-                
-                // Fire the completion!
-                completion?(response)
+                case let .failure(error):
+                    return .failure(error)
+                }
+            }()
+
+            // Create the DataResponse object containing all necessary information from the response
+            let response = DataResponse(request: dataResponse.request,
+                                        response: dataResponse.response,
+                                        data: dataResponse.data,
+                                        result: result)
+
+            // Fire the completion!
+            completion?(response)
         }
     }
-    
+
     /// Creates a configured URLRequest.
     /// - Parameter url: The URL for the request. Accepts a URL or a String.
     /// - Parameter method: The HTTP method for the request.
@@ -154,15 +156,15 @@ public class HTTPClient {
         guard let url = try? url.asURL() else {
             return nil
         }
-        
+
         var request = URLRequest(url: url)
         request.httpMethod = method.rawValue
-        
+
         request.setHeaders(headers)
-        
+
         // Parameters must be set after setting headers, because encoding dictates (and therefore overrides) the Content-Type header
         request.setParameters(parameters, method: method, encoding: encoding)
-        
+
         return request
     }
 }

--- a/Sources/UtilityBeltNetworking/HTTPClient.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient.swift
@@ -123,7 +123,6 @@ public class HTTPClient {
                         let decodedObject = try decoder.decode(T.self, from: data)
                         return .success(decodedObject)
                     } catch {
-//                            return .failure(UBNetworkError.unableToDecode(String(describing: T.self)))
                         return .failure(error)
                     }
                 case let .failure(error):

--- a/Sources/UtilityBeltNetworking/Protocols/HTTPHeaderConvertible.swift
+++ b/Sources/UtilityBeltNetworking/Protocols/HTTPHeaderConvertible.swift
@@ -1,0 +1,17 @@
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+/// A convenience protocol for converting an object into an HTTP header string.
+public protocol HTTPHeaderConvertible: Hashable {
+    /// Returns a `String` representation of this object.
+    var rawValue: String { get }
+}
+
+extension String: HTTPHeaderConvertible {
+    public var rawValue: String {
+        return self
+    }
+}
+
+extension HTTPHeader: HTTPHeaderConvertible { }

--- a/Sources/UtilityBeltNetworking/Protocols/HTTPHeaderConvertible.swift
+++ b/Sources/UtilityBeltNetworking/Protocols/HTTPHeaderConvertible.swift
@@ -14,4 +14,4 @@ extension String: HTTPHeaderConvertible {
     }
 }
 
-extension HTTPHeader: HTTPHeaderConvertible { }
+extension HTTPHeader: HTTPHeaderConvertible {}

--- a/Sources/UtilityBeltNetworking/Protocols/HTTPHeaderDictionaryConvertible.swift
+++ b/Sources/UtilityBeltNetworking/Protocols/HTTPHeaderDictionaryConvertible.swift
@@ -1,0 +1,21 @@
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+/// A convenience protocol for converting an object into an HTTP header dictionary.
+public protocol HTTPHeaderDictionaryConvertible {
+    /// Returns a `[String: String]` representation of this object.
+    func asHeaderDictionary() -> [String: String]
+}
+
+extension Dictionary: HTTPHeaderDictionaryConvertible where Key: HTTPHeaderConvertible, Value == String {
+    public func asHeaderDictionary() -> [String: String] {
+        var headers: [String: String] = [:]
+        
+        for element in self {
+            headers[element.key.rawValue] = element.value
+        }
+        
+        return headers
+    }
+}

--- a/Sources/UtilityBeltNetworking/Protocols/HTTPHeaderDictionaryConvertible.swift
+++ b/Sources/UtilityBeltNetworking/Protocols/HTTPHeaderDictionaryConvertible.swift
@@ -11,11 +11,11 @@ public protocol HTTPHeaderDictionaryConvertible {
 extension Dictionary: HTTPHeaderDictionaryConvertible where Key: HTTPHeaderConvertible, Value == String {
     public func asHeaderDictionary() -> [String: String] {
         var headers: [String: String] = [:]
-        
+
         for element in self {
             headers[element.key.rawValue] = element.value
         }
-        
+
         return headers
     }
 }

--- a/Sources/UtilityBeltNetworking/Protocols/URLConvertible.swift
+++ b/Sources/UtilityBeltNetworking/Protocols/URLConvertible.swift
@@ -2,10 +2,9 @@
 
 import Foundation
 
-/// A convenience protocol allowing the passing of Strings and other URL compatible classes
-/// to be used in places where a URL is typically required.
+/// A convenience protocol for converting an object into a `URL`.
 public protocol URLConvertible {
-    /// Returns a URL representation of this object.
+    /// Returns a `URL` representation of this object.
     func asURL() throws -> URL
 }
 

--- a/Sources/UtilityBeltNetworking/Protocols/URLRequestConvertible.swift
+++ b/Sources/UtilityBeltNetworking/Protocols/URLRequestConvertible.swift
@@ -2,10 +2,9 @@
 
 import Foundation
 
-/// A convenience protocol allowing the passing of Strings, URLs, and other URLRequest compatible classes
-/// to be used in places where a URLRequest is typically required.
+/// A convenience protocol for converting an object into a `URLRequest`.
 public protocol URLRequestConvertible {
-    /// Returns a URLRequest representation of this object.
+    /// Returns a `URLRequest` representation of this object.
     func asURLRequest() throws -> URLRequest
 }
 


### PR DESCRIPTION
**JIRA URL**
https://spothero.atlassian.net/browse/IOS-1940

**Description**
- Added `URLRequest+SetHeaders` extension method for adding a single header via the `HTTPHeader` enum or a dictionary headers.
- Added the `HTTPHeaderConvertible` for allowing easy passing of `String` and `HTTPHeader` types.
- Added the `HTTPHeaderDictionaryConvertible` for allowing singular `HTTPClient.request` methods to accept HTTP header dictionaries of any type. Also allows downstream consumers to implement their own `HTTPHeaderDictionaryConvertible` structs if they so desire.
- I haven't yet decided how I want to implement the `JSONDecoder` that can be passed into the `HTTPClient`, so for now I'm just passing it along with the request. I added a [ticket](https://spothero.atlassian.net/browse/IOS-1958) for tracking this work.
- Simplified some documentation around various protocols and methods.
- Added the `DataResponse.failure` convenience method.
