### PR TITLE
Added RFC3986 encoding to HTTPClient

### DIFF
--- a/Sources/UtilityBeltNetworking/Enums/UBNetworkError.swift
+++ b/Sources/UtilityBeltNetworking/Enums/UBNetworkError.swift
@@ -3,6 +3,7 @@
 import Foundation
 
 public enum UBNetworkError: Error {
+    case invalidContentType(String)
     case invalidFilePath(String)
     case invalidURLString(String)
     case invalidURLResponse
@@ -13,6 +14,8 @@ public enum UBNetworkError: Error {
 extension UBNetworkError: LocalizedError {
     public var errorDescription: String? {
         switch self {
+        case let .invalidContentType(contentType):
+            return "Invalid content type '\(contentType)'."
         case let .invalidFilePath(path):
             return "Invalid file path '\(path)'."
         case let .invalidURLString(urlString):

--- a/Sources/UtilityBeltNetworking/Extensions/CharacterSet+RFC3986Unreserved.swift
+++ b/Sources/UtilityBeltNetworking/Extensions/CharacterSet+RFC3986Unreserved.swift
@@ -1,0 +1,11 @@
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+extension CharacterSet {
+    /// Characters that are allowed in a URI but do not have a reserved purpose are called unreserved.
+    /// These include uppercase and lowercase letters, decimal digits, hyphen, period, underscore, and tilde.
+    ///
+    /// [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt) (see Section 2.3)
+    static let rfc3986Unreserved = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+}

--- a/Sources/UtilityBeltNetworking/Extensions/URLComponents+SetQueryItems.swift
+++ b/Sources/UtilityBeltNetworking/Extensions/URLComponents+SetQueryItems.swift
@@ -5,6 +5,18 @@ import Foundation
 extension URLComponents {
     mutating func setQueryItems(with parameters: [String: Any]) {
         self.queryItems = parameters.flatMap { self.evaluatedQueryItems(for: $0) }
+
+        // This will encode the query parameters following RFC 3986
+        self.percentEncodedQuery = self.queryItems?.compactMap {
+            guard
+                let escapedName = $0.name.addingPercentEncoding(withAllowedCharacters: .rfc3986Unreserved),
+                let escapedValue = $0.value?.addingPercentEncoding(withAllowedCharacters: .rfc3986Unreserved) else {
+                    return nil
+            }
+
+            return "\(escapedName)=\(escapedValue)"
+        }
+        .joined(separator: "&")
     }
 
     private func evaluatedQueryItems(for parameter: (key: String, value: Any)) -> [URLQueryItem] {

--- a/Sources/UtilityBeltNetworking/Extensions/URLComponents+SetQueryItems.swift
+++ b/Sources/UtilityBeltNetworking/Extensions/URLComponents+SetQueryItems.swift
@@ -11,7 +11,7 @@ extension URLComponents {
             guard
                 let escapedName = $0.name.addingPercentEncoding(withAllowedCharacters: .rfc3986Unreserved),
                 let escapedValue = $0.value?.addingPercentEncoding(withAllowedCharacters: .rfc3986Unreserved) else {
-                    return nil
+                return nil
             }
 
             return "\(escapedName)=\(escapedValue)"

--- a/Sources/UtilityBeltNetworking/HTTPClient.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient.swift
@@ -124,11 +124,12 @@ public class HTTPClient {
                         return .failure(UBNetworkError.unableToDecode(String(describing: T.self)))
                     }
                 case let .success(data):
-                    // If the mime type for the response isn't JSON, we can't decode it
-                    guard dataResponse.response?.mimeType == "application/json" else {
-                        return .failure(UBNetworkError.invalidContentType(dataResponse.response?.mimeType ?? "unknown"))
-                    }
-                    
+                    // TODO: Implement mime type checking for JSON before attempting to decode JSON (IOS-1967)
+//                    // If the mime type for the response isn't JSON, we can't decode it
+//                    guard dataResponse.response?.mimeType == "application/json" else {
+//                        return .failure(UBNetworkError.invalidContentType(dataResponse.response?.mimeType ?? "unknown"))
+//                    }
+
                     do {
                         let decodedObject = try decoder.decode(T.self, from: data)
                         return .success(decodedObject)

--- a/UtilityBelt.podspec
+++ b/UtilityBelt.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   # Root Specification
   spec.name = 'UtilityBelt'
-  spec.version = '0.4.5'
+  spec.version = '0.4.6'
 
   spec.author   = { 'SpotHero' => 'ios@spothero.com' }
   spec.homepage = 'https://github.com/spothero/UtilityBelt-iOS'


### PR DESCRIPTION
**Description**
- Added `CharacterSet+RFC3986Unreserved` extension to improve processing of URL encoded parameters.
- Added `Data` type checking to avoid decoding `Data` when it isn't necessary.
