### PR TITLE
IOS-1355: Added stub query string comparison that ignores sort order

### DIFF
--- a/Sources/Sham/Models/StubRequest.swift
+++ b/Sources/Sham/Models/StubRequest.swift
@@ -206,11 +206,11 @@ private extension URL {
     }
 
     func hasQueryStringEqualTo(url otherURL: URL) -> Bool {
-        // Split the query string apart by key/value pairs, then sort and rejoin
+        // Split the query string apart by key/value pairs, then sort
         let selfQuery = self.query?.split(separator: "&").sorted(by: { $0 < $1 })
         let requestQuery = otherURL.query?.split(separator: "&").sorted(by: { $0 < $1 })
 
-        // Compare the full strings to ensure they match
+        // Compare the query arrays to ensure they match
         return selfQuery == requestQuery
     }
 }

--- a/Sources/Sham/Models/StubRequest.swift
+++ b/Sources/Sham/Models/StubRequest.swift
@@ -93,19 +93,19 @@ public struct StubRequest: Hashable, CustomStringConvertible {
         }
 
         // Include any stubbed response where the scheme matches the incoming URL's scheme or is nil or empty
-        let validScheme = url.scheme == requestURL.scheme || url.scheme.isNilOrEmpty
+        let validScheme = url.scheme.isNilOrEmpty || url.scheme == requestURL.scheme
 
         // Include any stubbed response where the host matches the incoming URL's host or is nil or empty
-        let validHost = url.host == requestURL.host || url.host.isNilOrEmpty
+        let validHost = url.host.isNilOrEmpty || url.host == requestURL.host
 
         // Include any stubbed response where the port matches the incoming URL's port or is nil
-        let validPort = url.port == requestURL.port || url.port == nil
+        let validPort = url.port == nil || url.port == requestURL.port
 
         // Include any stubbed response where the path matches the incoming URL's path or is empty
-        let validPath = url.trimmedPath == requestURL.trimmedPath || url.trimmedPath.isEmpty
+        let validPath = url.trimmedPath.isEmpty || url.trimmedPath == requestURL.trimmedPath
 
         // Include any stubbed response where the query matches the incoming URL's query or is nil or empty
-        let validQuery = url.query == requestURL.query || url.query.isNilOrEmpty
+        let validQuery = url.query.isNilOrEmpty || url.hasQueryStringEqualTo(url: requestURL)
 
         return validScheme && validHost && validPort && validPath && validQuery
     }
@@ -203,5 +203,14 @@ private extension URL {
         // In order for a URL to be considered valid for stubbing,
         // it must have a non-empty path or a non-nil and non-empty host
         return !self.path.isEmpty || self.host?.isEmpty == false
+    }
+
+    func hasQueryStringEqualTo(url otherURL: URL) -> Bool {
+        // Split the query string apart by key/value pairs, then sort and rejoin
+        let selfQuery = self.query?.split(separator: "&").sorted(by: { $0 < $1 }).joined(separator: "&")
+        let requestQuery = otherURL.query?.split(separator: "&").sorted(by: { $0 < $1 }).joined(separator: "&")
+
+        // Compare the full strings to ensure they match
+        return selfQuery == requestQuery
     }
 }

--- a/Sources/Sham/Models/StubRequest.swift
+++ b/Sources/Sham/Models/StubRequest.swift
@@ -207,8 +207,8 @@ private extension URL {
 
     func hasQueryStringEqualTo(url otherURL: URL) -> Bool {
         // Split the query string apart by key/value pairs, then sort and rejoin
-        let selfQuery = self.query?.split(separator: "&").sorted(by: { $0 < $1 }).joined(separator: "&")
-        let requestQuery = otherURL.query?.split(separator: "&").sorted(by: { $0 < $1 }).joined(separator: "&")
+        let selfQuery = self.query?.split(separator: "&").sorted(by: { $0 < $1 })
+        let requestQuery = otherURL.query?.split(separator: "&").sorted(by: { $0 < $1 })
 
         // Compare the full strings to ensure they match
         return selfQuery == requestQuery

--- a/Tests/ShamTests/Tests/StubRequestTests.swift
+++ b/Tests/ShamTests/Tests/StubRequestTests.swift
@@ -1,0 +1,15 @@
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
+
+import Foundation
+@testable import Sham
+import UtilityBeltNetworking
+import XCTest
+
+final class StubRequestTests: XCTestCase {
+    func testRandomizedQueryStringOrderComparisonSucceeds() {
+        let request: StubRequest = .get("https://spothero.local?shape=triangle&color=blue")
+        let canMockData = request.canMockData(for: .get("https://spothero.local?color=blue&shape=triangle"))
+
+        XCTAssertTrue(canMockData, "Unable to mock data for request.")
+    }
+}

--- a/UtilityBelt.podspec
+++ b/UtilityBelt.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   # Root Specification
   spec.name = 'UtilityBelt'
-  spec.version = '0.4.6'
+  spec.version = '0.4.7'
 
   spec.author   = { 'SpotHero' => 'ios@spothero.com' }
   spec.homepage = 'https://github.com/spothero/UtilityBelt-iOS'


### PR DESCRIPTION
**JIRA URL**
https://spothero.atlassian.net/browse/IOS-1355

**Description**
- Added ability for stubbed requests to validate based on query string parameters regardless of the order they are being requested.
- Inverted validation checks in `StubRequest.canMockData` for optimization.