### PR TITLE
Added open-source notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UtilityBelt-iOS
 
-[![Build Status](https://app.bitrise.io/app/998bf00ec3834716/status.svg?token=afkazBEiSRY9D1wIn9OpgQ&branch=master)](https://app.bitrise.io/app/998bf00ec3834716)
+[![Build Status](https://app.bitrise.io/app/ca194f397ea8421e/status.svg?token=mWTkOH26hJthuWEGXK-vOA&branch=master)](https://app.bitrise.io/app/ca194f397ea8421e)
 
 UtilityBelt is a collection of utilities used across various applications and libraries.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,30 @@
 # UtilityBelt-iOS
 
 [![Build Status](https://app.bitrise.io/app/998bf00ec3834716/status.svg?token=afkazBEiSRY9D1wIn9OpgQ&branch=master)](https://app.bitrise.io/app/998bf00ec3834716)
+
+UtilityBelt is a collection of utilities used across various applications and libraries.
+
+>:warning: The code in this library has been provided as-is. SpotHero uses this library in Production, but it may lack the documentation, stability, and functionality necessary to support external use. While we work on improving this codebase, **use this library at your own risk** and please [reach out](#communication) if you have any questions or feedback.
+
+- [Installation](#installation)
+- [Communication](#communication)
+
+## Installation
+
+### Swift Package Manager
+
+[Swift Package Manager](https://swift.org/package-manager/) is built into the Swift toolchain and is our preferred way of integrating the SDK.
+
+For Swift package projects, simply add the following line to your `Package.swift` file in the `dependencies` section:
+
+```swift
+dependencies: [
+  .package(url: "https://github.com/spothero/UtilityBelt-iOS", .upToNextMajor(from: "<version>")),
+]
+```
+
+For app projects, simply follow the [Apple documentation](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app) on adding package dependencies to your app.
+
+## Communication
+
+For all bug reports, feature requests, and general communication, please open an issue to get in contact with us.

--- a/Tests/UtilityBeltNetworkingTests/Tests/ParameterEncodingTests.swift
+++ b/Tests/UtilityBeltNetworkingTests/Tests/ParameterEncodingTests.swift
@@ -130,7 +130,7 @@ final class ParameterEncodingTests: XCTestCase {
     /// - Parameter request: The request to check.
     private func dataIsInBody(request: URLRequest) {
         let jsonSerialized: Data
-        if #available(OSX 10.13, *) {
+        if #available(iOS 11.0, OSX 10.13, *) {
             guard let serialized = try? JSONSerialization.data(withJSONObject: self.parameters, options: .sortedKeys) else {
                 assertionFailure("Failed to serialized mocked parameters")
                 return

--- a/UtilityBelt.xcworkspace/xcshareddata/xcschemes/UtilityBelt.xcscheme
+++ b/UtilityBelt.xcworkspace/xcshareddata/xcschemes/UtilityBelt.xcscheme
@@ -84,20 +84,6 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "345796EA2391DFFF0009C62D"
-               BuildableName = "UtilityBeltDemo.app"
-               BlueprintName = "UtilityBeltDemo"
-               ReferencedContainer = "container:UtilityBeltTests/UtilityBeltTests.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "34E5ABC724620DD90070A80B"
                BuildableName = "RunScriptHelper"
                BlueprintName = "RunScriptHelper"

--- a/Zincfile
+++ b/Zincfile
@@ -7,8 +7,6 @@ files:
   # GitHub
   - source_path: Tools/GitHub/CODEOWNERS
     destination_path: .github
-  - source_path: Tools/GitHub/pull_request_template.md
-    destination_path: .github
   - source_path: Tools/GitHub/.gitignore
   # Rubocop
   - source_path: Tools/Rubocop/rubocop.yml


### PR DESCRIPTION
**Description**
- Deleted the `pull_request_template.md` from this library and removed it from Zincfile. We'll rely on the Organization's [default community health file repository](http://github.com/spothero/.github) while it aligns.
- Updated README to include a notice of the state of the repository.