### PR TITLE
Add a prioritization score to match incoming requests

### DIFF
--- a/Sources/Sham/MockService.swift
+++ b/Sources/Sham/MockService.swift
@@ -70,7 +70,7 @@ public class MockService {
         if response == nil {
             // Use the response associated with the highest scoring match for stubbed requests
             response = self.stubbedData.max {
-                $0.key.priorityScore(for: request) < $1.key.priorityScore(for: request)
+                $0.key.priorityScore(for: request) > $1.key.priorityScore(for: request)
             }?.value
         }
         

--- a/Sources/Sham/MockService.swift
+++ b/Sources/Sham/MockService.swift
@@ -70,7 +70,7 @@ public class MockService {
         if response == nil {
             // Use the response associated with the highest scoring match for stubbed requests
             response = self.stubbedData.max {
-                $0.key.priorityScore(for: request) > $1.key.priorityScore(for: request)
+                $0.key.priorityScore(for: request) < $1.key.priorityScore(for: request)
             }?.value
         }
         

--- a/Sources/Sham/MockService.swift
+++ b/Sources/Sham/MockService.swift
@@ -68,10 +68,25 @@ public class MockService {
         
         // If response had no exact match, we need to find the closest match
         if response == nil {
-            // Use the response associated with the highest scoring match for stubbed requests
-            response = self.stubbedData.max {
-                $0.key.priorityScore(for: request) > $1.key.priorityScore(for: request)
-            }?.value
+            var bestScore: Int?
+            var bestResponse: StubResponse?
+            
+            for (cachedRequest, cachedResponse) in self.stubbedData {
+                guard
+                    // If there is a priority score
+                    let priorityScore = cachedRequest.priorityScore(for: request),
+                    // and its better than anything we have found yet
+                    priorityScore > bestScore ?? 0 else {
+                    continue
+                }
+                
+                // store this score and response - its the best matching stub so far
+                bestScore = priorityScore
+                bestResponse = cachedResponse
+            }
+            
+            // Use the best response we found, if any
+            response = bestResponse
         }
         
         // Log response debugging information

--- a/Sources/Sham/MockService.swift
+++ b/Sources/Sham/MockService.swift
@@ -72,7 +72,7 @@ public class MockService {
     /// Returns nil if there is no matching stubbed request found.
     /// - Parameter request: The request to match against stubbed requests.
     public func getResponse(for request: StubRequest) -> StubResponse? {
-        self.log("Attempting to stub request: \(request)")
+        self.log("Attempting to stub request: \(request.description)")
         
         // Check for a match with the exact URL
         var response = self.stubbedData[request]
@@ -90,8 +90,6 @@ public class MockService {
                     priorityScore > bestScore ?? 0 else {
                     continue
                 }
-                print("priorityScore: \(priorityScore)")
-                print("req: \(cachedRequest.description)")
                 
                 // store this score and response - its the best matching stub so far
                 bestScore = priorityScore

--- a/Sources/Sham/MockService.swift
+++ b/Sources/Sham/MockService.swift
@@ -25,11 +25,6 @@ public class MockService {
     /// A dictionary of stubbed responses keyed by stubbed requests.
     private var stubbedData = [StubRequest: StubResponse]()
     
-//    /// A convenience array of stubbed requests, taken from stubbedData dictionary keys.
-//    private var stubbedRequests: [StubRequest] {
-//        return self.stubbedData.keys
-//    }
-    
     /// Whether or not there are any stubbed response.
     public var hasStubs: Bool {
         return !self.stubbedData.isEmpty

--- a/Sources/Sham/MockService.swift
+++ b/Sources/Sham/MockService.swift
@@ -68,25 +68,10 @@ public class MockService {
         
         // If response had no exact match, we need to find the closest match
         if response == nil {
-            var bestScore: Int?
-            var bestResponse: StubResponse?
-            
-            for (cachedRequest, cachedResponse) in self.stubbedData {
-                guard
-                    // If there is a priority score
-                    let priorityScore = cachedRequest.priorityScore(for: request),
-                    // and its better than anything we have found yet
-                    priorityScore > bestScore ?? 0 else {
-                    continue
-                }
-                
-                // store this score and response - its the best matching stub so far
-                bestScore = priorityScore
-                bestResponse = cachedResponse
-            }
-            
-            // Use the best response we found, if any
-            response = bestResponse
+            // Use the response associated with the highest scoring match for stubbed requests
+            response = self.stubbedData.max {
+                $0.key.priorityScore(for: request) > $1.key.priorityScore(for: request)
+            }?.value
         }
         
         // Log response debugging information

--- a/Sources/Sham/MockService.swift
+++ b/Sources/Sham/MockService.swift
@@ -79,11 +79,27 @@ public class MockService {
         
         // If response had no exact match, we need to find the closest match
         if response == nil {
-            // Otherwise, find the first matching stubbed request/response pair for the given request
-            let firstStubbedDataPair = self.stubbedData.first { $0.key.canMockData(for: request) }
+            var bestScore: Int?
+            var bestResponse: StubResponse?
             
-            // Return the stubbed response from the first stubbed data pair found, or return nil
-            response = firstStubbedDataPair?.value
+            for (cachedRequest, cachedResponse) in self.stubbedData {
+                guard
+                    // If there is a priority score
+                    let priorityScore = cachedRequest.priorityScore(for: request),
+                    // and its better than anything we have found yet
+                    priorityScore > bestScore ?? 0 else {
+                    continue
+                }
+                print("priorityScore: \(priorityScore)")
+                print("req: \(cachedRequest.description)")
+                
+                // store this score and response - its the best matching stub so far
+                bestScore = priorityScore
+                bestResponse = cachedResponse
+            }
+            
+            // Use the best response we found, if any
+            response = bestResponse
         }
         
         // Log response debugging information

--- a/Sources/Sham/MockService.swift
+++ b/Sources/Sham/MockService.swift
@@ -68,25 +68,15 @@ public class MockService {
         
         // If response had no exact match, we need to find the closest match
         if response == nil {
-            var bestScore: Int?
-            var bestResponse: StubResponse?
-            
-            for (cachedRequest, cachedResponse) in self.stubbedData {
-                guard
-                    // If there is a priority score
-                    let priorityScore = cachedRequest.priorityScore(for: request),
-                    // and its better than anything we have found yet
-                    priorityScore > bestScore ?? 0 else {
-                    continue
-                }
-                
-                // store this score and response - its the best matching stub so far
-                bestScore = priorityScore
-                bestResponse = cachedResponse
+            // Filter out stubs that can not mock this request
+            let availableStubs = self.stubbedData.filter {
+                return $0.key.canMockData(for: request)
             }
             
-            // Use the best response we found, if any
-            response = bestResponse
+            // Find the highest priority matching score to get the best response
+            response = availableStubs.max {
+                $0.key.priorityScore(for: request) < $1.key.priorityScore(for: request)
+            }?.value
         }
         
         // Log response debugging information

--- a/Sources/Sham/Models/StubRequest.swift
+++ b/Sources/Sham/Models/StubRequest.swift
@@ -111,8 +111,8 @@ public struct StubRequest: Hashable, CustomStringConvertible {
         return validScheme && validHost && validPort && validPath && validQuery
     }
     
-    /// A function that generates a score to represent how well a StubRequest matches an incoming request
-    /// - Parameter request: The request to generate the priority score against
+    /// A function that generates a score to represent how well a stored stubbed request matches an incoming request
+    /// - Parameter request: The incoming request to generate the priority score against
     /// - Returns: A score representing how well this request matches an incoming request.  Nil values imply no match.
     public func priorityScore(for request: StubRequest) -> Int? {
         guard self.canMockData(for: request) else {
@@ -249,7 +249,7 @@ private extension URL {
     
     /// Returns the absolute url string with sorted query parameters
     var sortedAbsoluteString: String? {
-        var urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: true)
+        var urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: false)
         urlComponents?.query = self.sortedQueryString
         return urlComponents?.string
     }

--- a/Sources/Sham/Models/StubRequest.swift
+++ b/Sources/Sham/Models/StubRequest.swift
@@ -4,7 +4,7 @@ import Foundation
 import UtilityBeltNetworking
 
 /// A request for stubbing response meant to mirror a URLRequest.
-public struct StubRequest: CustomStringConvertible {
+public struct StubRequest: Hashable, CustomStringConvertible {
     // MARK: - Properties
     
     /// The HTTP method to stub. If nil, stubs all methods.
@@ -110,17 +110,43 @@ public struct StubRequest: CustomStringConvertible {
         
         return validScheme && validHost && validPort && validPath && validQuery
     }
-}
-
-// MARK: - Hashable and Equatable
-
-extension StubRequest: Hashable, Equatable {
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(self.description)
-    }
     
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        return lhs.hashValue == rhs.hashValue
+    public func priorityScore(for request: StubRequest) -> Int? {
+        guard self.canMockData(for: request) else {
+            return nil
+        }
+        
+        var score = 0
+        
+        if self.method == request.method {
+            score += 1
+        }
+        
+        guard let url = self.url else {
+            return score
+        }
+        
+        if url.scheme == request.url?.scheme {
+            score += 1
+        }
+        
+        if url.host == request.url?.host {
+            score += 1
+        }
+        
+        if url.port == request.url?.port {
+            score += 1
+        }
+        
+        if url.trimmedPath == request.url?.trimmedPath {
+            score += 1
+        }
+        
+        if url.sortedQueryString == request.url?.sortedQueryString {
+            score += 1
+        }
+        
+        return score
     }
 }
 

--- a/Sources/Sham/Models/StubRequest.swift
+++ b/Sources/Sham/Models/StubRequest.swift
@@ -111,14 +111,11 @@ public struct StubRequest: Hashable, CustomStringConvertible {
         return validScheme && validHost && validPort && validPath && validQuery
     }
     
-    /// A function that generates a score to represent how well a stored stubbed request matches an incoming request
-    /// - Parameter request: The incoming request to generate the priority score against
-    /// - Returns: A score representing how well this request matches an incoming request.  Nil values imply no match.
-    public func priorityScore(for request: StubRequest) -> Int? {
-        guard self.canMockData(for: request) else {
-            return nil
-        }
-        
+    /// A function that generates a score to represent how well a stored stubbed request matches an incoming request, with
+    /// 0 indicating no match and higher scores representing better matches.
+    /// - Parameter request: The incoming request to generate the priority score against.
+    /// - Returns: A score representing how well this request matches an incoming request.  Hight scores indicate better matches.
+    public func priorityScore(for request: StubRequest) -> Int {
         var score = 0
         
         if self.method == request.method {

--- a/Sources/Sham/Models/StubRequest.swift
+++ b/Sources/Sham/Models/StubRequest.swift
@@ -111,6 +111,9 @@ public struct StubRequest: Hashable, CustomStringConvertible {
         return validScheme && validHost && validPort && validPath && validQuery
     }
     
+    /// A function that generates a score to represent how well a StubRequest matches an incoming request
+    /// - Parameter request: The request to generate the priority score against
+    /// - Returns: A score representing how well this request matches an incoming request.  Nil values imply no match.
     public func priorityScore(for request: StubRequest) -> Int? {
         guard self.canMockData(for: request) else {
             return nil

--- a/Sources/Sham/Models/StubRequest.swift
+++ b/Sources/Sham/Models/StubRequest.swift
@@ -111,16 +111,15 @@ public struct StubRequest: Hashable, CustomStringConvertible {
         return validScheme && validHost && validPort && validPath && validQuery
     }
     
-    /// A function that generates a score to represent how well a stored stubbed request matches an incoming request, with
-    /// 0 indicating no match and higher scores representing better matches.
-    /// - Parameter request: The incoming request to generate the priority score against.
-    /// - Returns: A score representing how well this request matches an incoming request.  Hight scores indicate better matches.
-    public func priorityScore(for request: StubRequest) -> Int {
-        var score = 0
-        
+    /// A function that generates a score to represent how well a stored stubbed request matches an incoming request
+    /// - Parameter request: The incoming request to generate the priority score against
+    /// - Returns: A score representing how well this request matches an incoming request.  Nil values imply no match.
+    public func priorityScore(for request: StubRequest) -> Int? {
         guard self.canMockData(for: request) else {
-            return score
+            return nil
         }
+        
+        var score = 0
         
         if self.method == request.method {
             score += 1

--- a/Sources/Sham/Models/StubRequest.swift
+++ b/Sources/Sham/Models/StubRequest.swift
@@ -111,15 +111,16 @@ public struct StubRequest: Hashable, CustomStringConvertible {
         return validScheme && validHost && validPort && validPath && validQuery
     }
     
-    /// A function that generates a score to represent how well a stored stubbed request matches an incoming request
-    /// - Parameter request: The incoming request to generate the priority score against
-    /// - Returns: A score representing how well this request matches an incoming request.  Nil values imply no match.
-    public func priorityScore(for request: StubRequest) -> Int? {
-        guard self.canMockData(for: request) else {
-            return nil
-        }
-        
+    /// A function that generates a score to represent how well a stored stubbed request matches an incoming request, with
+    /// 0 indicating no match and higher scores representing better matches.
+    /// - Parameter request: The incoming request to generate the priority score against.
+    /// - Returns: A score representing how well this request matches an incoming request.  Hight scores indicate better matches.
+    public func priorityScore(for request: StubRequest) -> Int {
         var score = 0
+        
+        guard self.canMockData(for: request) else {
+            return score
+        }
         
         if self.method == request.method {
             score += 1

--- a/Tests/ShamTests/Tests/MockServiceTests.swift
+++ b/Tests/ShamTests/Tests/MockServiceTests.swift
@@ -130,23 +130,4 @@ final class MockServiceTests: XCTestCase {
         
         self.waitForExpectations(timeout: 5)
     }
-    
-    func testQueryParameterMatching() {
-        let baseURLResponse: StubResponse = .encodable("Base URL Response")
-        let rightResponse: StubResponse = .encodable("Right Response")
-        // swiftlint:disable:next line_length
-        let fullString = "api/v1/facilities/769/rates/?show_unavailable=true&session_uuid=DCAFF36A-A268-4FFB-9CAC-63963DF12374&starts=2018-06-06T12%3A30&search_text=&ends=2018-06-06T18%3A00&auto_extend=true&action_id=6EB2D9E2-90B0-4A09-A3BB-0A287F50B2C3&action=rebook_recent_reservations&segment_id=TESTING&include=facility%2Cfacility.operator_id%2Cfacility.supported_fee_types&search_id=158ED109-3F21-45E6-BA63-6A0999A8F69B"
-        
-        let base = "api/v1/facilities/769/rates/"
-        
-        self.stub(.get(base), with: baseURLResponse)
-        self.stub(.get(fullString), with: rightResponse)
-        // swiftlint:disable:next line_length
-        let rearranged = "api/v1/facilities/769/rates/?show_unavailable=true&session_uuid=DCAFF36A-A268-4FFB-9CAC-63963DF12374&starts=2018-06-06T12%3A30&search_text=&auto_extend=true&action_id=6EB2D9E2-90B0-4A09-A3BB-0A287F50B2C3&action=rebook_recent_reservations&segment_id=TESTING&include=facility%2Cfacility.operator_id%2Cfacility.supported_fee_types&ends=2018-06-06T18%3A00&search_id=158ED109-3F21-45E6-BA63-6A0999A8F69B"
-        
-        let testResult = MockService.shared.getResponse(for: StubRequest.get(rearranged))
-        print("1. \(String(data: testResult!.data!, encoding: .utf8))")
-        XCTAssertNotNil(testResult?.data)
-        XCTAssertEqual(testResult?.data, rightResponse.data)
-    }
 }

--- a/Tests/ShamTests/Tests/MockServiceTests.swift
+++ b/Tests/ShamTests/Tests/MockServiceTests.swift
@@ -130,4 +130,23 @@ final class MockServiceTests: XCTestCase {
         
         self.waitForExpectations(timeout: 5)
     }
+    
+    func testQueryParameterMatching() {
+        let baseURLResponse: StubResponse = .encodable("Base URL Response")
+        let rightResponse: StubResponse = .encodable("Right Response")
+        // swiftlint:disable:next line_length
+        let fullString = "api/v1/facilities/769/rates/?show_unavailable=true&session_uuid=DCAFF36A-A268-4FFB-9CAC-63963DF12374&starts=2018-06-06T12%3A30&search_text=&ends=2018-06-06T18%3A00&auto_extend=true&action_id=6EB2D9E2-90B0-4A09-A3BB-0A287F50B2C3&action=rebook_recent_reservations&segment_id=TESTING&include=facility%2Cfacility.operator_id%2Cfacility.supported_fee_types&search_id=158ED109-3F21-45E6-BA63-6A0999A8F69B"
+        
+        let base = "api/v1/facilities/769/rates/"
+        
+        self.stub(.get(base), with: baseURLResponse)
+        self.stub(.get(fullString), with: rightResponse)
+        // swiftlint:disable:next line_length
+        let rearranged = "api/v1/facilities/769/rates/?show_unavailable=true&session_uuid=DCAFF36A-A268-4FFB-9CAC-63963DF12374&starts=2018-06-06T12%3A30&search_text=&auto_extend=true&action_id=6EB2D9E2-90B0-4A09-A3BB-0A287F50B2C3&action=rebook_recent_reservations&segment_id=TESTING&include=facility%2Cfacility.operator_id%2Cfacility.supported_fee_types&ends=2018-06-06T18%3A00&search_id=158ED109-3F21-45E6-BA63-6A0999A8F69B"
+        
+        let testResult = MockService.shared.getResponse(for: StubRequest.get(rearranged))
+        print("1. \(String(data: testResult!.data!, encoding: .utf8))")
+        XCTAssertNotNil(testResult?.data)
+        XCTAssertEqual(testResult?.data, rightResponse.data)
+    }
 }


### PR DESCRIPTION
**Description**
- removes os logging and replaces it with configurable print calls
- removes previous hashable implementation that didnt handle base URLs well
- creates a simple priority function that will prioritize the best matching stubbed request for incoming requests 