### PR TITLE
IOS-1930: feature/add CoreData fetch request test coverage

### DIFF
--- a/Tests/UtilityBeltDataTests/Tests/CoreData/CoreDataOperatorInMemoryTests.swift
+++ b/Tests/UtilityBeltDataTests/Tests/CoreData/CoreDataOperatorInMemoryTests.swift
@@ -35,6 +35,32 @@ final class CoreDataOperatorInMemoryTests: XCTestCase, CoreDataOperatorTesting {
         self.verifyCountWithPredicateSucceeds()
     }
     
+    // MARK: Fetch Tests
+    
+    func testFetch() {
+        self.verifyFetchSucceeds()
+    }
+    
+    func testFetchWithPredicate() {
+        self.verifyFetchWithPredicateSucceeds()
+    }
+    
+    func testFetchMultiple() {
+        self.verifyFetchMultipleSucceeds()
+    }
+    
+    func testFetchMultipleWithPredicate() {
+        self.verifyFetchMultipleWithPredicateSucceeds()
+    }
+    
+    func testFetchMultipleWithSortDescriptors() {
+        self.verifyFetchMultipleWithSortDescriptorsSucceeds()
+    }
+    
+    func testFetchMultipleWithFetchLimit() {
+        self.verifyFetchMultipleWithFetchLimitSucceeds()
+    }
+    
     // MARK: Delete Tests
     
     func testDeleteSingleObject() {

--- a/Tests/UtilityBeltDataTests/Tests/CoreData/CoreDataOperatorSQLiteTests.swift
+++ b/Tests/UtilityBeltDataTests/Tests/CoreData/CoreDataOperatorSQLiteTests.swift
@@ -35,6 +35,32 @@ final class CoreDataOperatorSQLiteTests: XCTestCase, CoreDataOperatorTesting {
         self.verifyCountWithPredicateSucceeds()
     }
     
+    // MARK: Fetch Tests
+    
+    func testFetch() {
+        self.verifyFetchSucceeds()
+    }
+    
+    func testFetchWithPredicate() {
+        self.verifyFetchWithPredicateSucceeds()
+    }
+    
+    func testFetchMultiple() {
+        self.verifyFetchMultipleSucceeds()
+    }
+    
+    func testFetchMultipleWithPredicate() {
+        self.verifyFetchMultipleWithPredicateSucceeds()
+    }
+    
+    func testFetchMultipleWithSortDescriptors() {
+        self.verifyFetchMultipleWithSortDescriptorsSucceeds()
+    }
+    
+    func testFetchMultipleWithFetchLimit() {
+        self.verifyFetchMultipleWithFetchLimitSucceeds()
+    }
+    
     // MARK: Delete Tests
     
     func testDeleteSingleObject() {


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-1930

**Description**
Adding test coverage for:
- Individual entity fetch requests 
- Individual entity fetch requests with predicate
- Multiple entity fetch requests
- Multiple entity fetch requests with predicate
- Multiple entity fetch requests with sort descriptors 
- Multiple entity fetch requests with fetch limits