### PR TITLE
IOS-1943: Updated for Encodable and ParameterConvertible support

### DIFF
--- a/Sources/UtilityBeltNetworking/Extensions/Encodable+AsDictionary.swift
+++ b/Sources/UtilityBeltNetworking/Extensions/Encodable+AsDictionary.swift
@@ -1,0 +1,10 @@
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+extension Encodable {
+    func asDictionary() throws -> [String: Any]? {
+        let data = try JSONEncoder().encode(self)
+        return try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any]
+    }
+}

--- a/Sources/UtilityBeltNetworking/Extensions/URLRequest+SetParameters.swift
+++ b/Sources/UtilityBeltNetworking/Extensions/URLRequest+SetParameters.swift
@@ -10,13 +10,13 @@ extension URLRequest {
     //       1, method without encoding: Use the default method's encoding.
     //       2. method with encoding: Use the method, but override the encoding.
     //       3. encoding without method: Doesn't matter what method, override the encoding.
-    mutating func setParameters(_ parameters: [String: Any]?, method: HTTPMethod, encoding: ParameterEncoding? = nil) {
+    mutating func setParameters(_ parameters: ParameterDictionaryConvertible?, method: HTTPMethod, encoding: ParameterEncoding? = nil) {
         let encoding = encoding ?? .defaultEncoding(for: method)
         self.setParameters(parameters, encoding: encoding)
     }
     
-    mutating func setParameters(_ parameters: [String: Any]?, encoding: ParameterEncoding) {
-        guard let url = self.url, let parameters = parameters else {
+    mutating func setParameters(_ parameters: ParameterDictionaryConvertible?, encoding: ParameterEncoding) {
+        guard let url = self.url, let parameters = parameters?.asParameterDictionary() else {
             return
         }
         
@@ -45,24 +45,12 @@ extension URLRequest {
     }
     
     mutating func setParameters(_ encodable: Encodable, method: HTTPMethod, encoding: ParameterEncoding? = nil) {
-        let parameters = encodable.asParameters()
+        let parameters = try? encodable.asDictionary()
         self.setParameters(parameters, method: method, encoding: encoding)
     }
     
     mutating func setParameters(_ encodable: Encodable, encoding: ParameterEncoding) {
-        let parameters = encodable.asParameters()
+        let parameters = try? encodable.asDictionary()
         self.setParameters(parameters, encoding: encoding)
-    }
-}
-
-private extension Encodable {
-    func asParameters() -> [String: Any]? {
-        guard let data = try? JSONEncoder().encode(self) else {
-            return nil
-        }
-        
-        let decodedData = try? JSONSerialization.jsonObject(with: data, options: .allowFragments)
-        
-        return decodedData.flatMap { $0 as? [String: Any] }
     }
 }

--- a/Sources/UtilityBeltNetworking/HTTPClient+Combine.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient+Combine.swift
@@ -4,11 +4,10 @@ import Combine
 import Foundation
 
 @available(iOS 13, macOS 10.15, tvOS 13.0, watchOS 6, *)
-extension HTTPClient {
+public extension HTTPClient {
     // MARK: Data Response
     
     /// Creates a request publisher which fetches raw data from an endpoint.
-    /// Returns a `URLSessionTask`, which allows for cancellation and retries.
     /// - Parameter url: The URL for the request. Accepts a URL or a String.
     /// - Parameter method: The HTTP method for the request. Defaults to `GET`.
     /// - Parameter parameters: The parameters to be converted into a String-keyed dictionary to send in the query string or HTTP body.
@@ -68,7 +67,6 @@ extension HTTPClient {
     }
     
     /// Creates a request publisher which fetches raw data from an endpoint.
-    /// Returns a `URLSessionTask`, which allows for cancellation and retries.
     /// - Parameter url: The URL for the request. Accepts a URL or a String.
     /// - Parameter method: The HTTP method for the request. Defaults to `GET`.
     /// - Parameter parameters: The `Encodable` object to be converted into a String-keyed dictionary to send in the query string or HTTP body.
@@ -91,7 +89,6 @@ extension HTTPClient {
     // MARK: Decodable Object Response
     
     /// Creates a request publisher which fetches raw data from an endpoint and decodes it.
-    /// Returns a `URLSessionTask`, which allows for cancellation and retries.
     /// - Parameter url: The URL for the request. Accepts a URL or a String.
     /// - Parameter method: The HTTP method for the request. Defaults to `GET`.
     /// - Parameter parameters: The parameters to be converted into a String-keyed dictionary to send in the query string or HTTP body.
@@ -119,7 +116,6 @@ extension HTTPClient {
     }
     
     /// Creates a request publisher which fetches raw data from an endpoint and decodes it.
-    /// Returns a `URLSessionTask`, which allows for cancellation and retries.
     /// - Parameter url: The URL for the request. Accepts a URL or a String.
     /// - Parameter method: The HTTP method for the request. Defaults to `GET`.
     /// - Parameter parameters: The `Encodable` object to be converted into a String-keyed dictionary to send in the query string or HTTP body.

--- a/Sources/UtilityBeltNetworking/HTTPClient+Combine.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient+Combine.swift
@@ -5,9 +5,19 @@ import Foundation
 
 @available(iOS 13, macOS 10.15, tvOS 13.0, watchOS 6, *)
 extension HTTPClient {
+    // MARK: Data Response
+    
+    /// Creates a request publisher which fetches raw data from an endpoint.
+    /// Returns a `URLSessionTask`, which allows for cancellation and retries.
+    /// - Parameter url: The URL for the request. Accepts a URL or a String.
+    /// - Parameter method: The HTTP method for the request. Defaults to `GET`.
+    /// - Parameter parameters: The parameters to be converted into a String-keyed dictionary to send in the query string or HTTP body.
+    /// - Parameter headers: The HTTP headers to send with the request.
+    /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
+    /// - Returns: A publisher that wraps a data task for the URL.
     func requestPublisher(_ url: URLConvertible,
-                          method: HTTPMethod,
-                          parameters: [String: Any]? = nil,
+                          method: HTTPMethod = .get,
+                          parameters: ParameterDictionaryConvertible? = nil,
                           headers: HTTPHeaderDictionaryConvertible? = nil,
                           encoding: ParameterEncoding? = nil) -> AnyPublisher<Data, Error> {
         let request: URLRequest
@@ -57,9 +67,41 @@ extension HTTPClient {
             .eraseToAnyPublisher()
     }
     
+    /// Creates a request publisher which fetches raw data from an endpoint.
+    /// Returns a `URLSessionTask`, which allows for cancellation and retries.
+    /// - Parameter url: The URL for the request. Accepts a URL or a String.
+    /// - Parameter method: The HTTP method for the request. Defaults to `GET`.
+    /// - Parameter parameters: The `Encodable` object to be converted into a String-keyed dictionary to send in the query string or HTTP body.
+    /// - Parameter headers: The HTTP headers to send with the request.
+    /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
+    /// - Returns: A publisher that wraps a data task for the URL.
+    // swiftlint:disable:next function_default_parameter_at_end
+    func requestPublisher(_ url: URLConvertible,
+                          method: HTTPMethod = .get,
+                          parameters: Encodable,
+                          headers: HTTPHeaderDictionaryConvertible? = nil,
+                          encoding: ParameterEncoding? = nil) -> AnyPublisher<Data, Error> {
+        return self.requestPublisher(url,
+                                     method: method,
+                                     parameters: try? parameters.asDictionary(),
+                                     headers: headers,
+                                     encoding: encoding)
+    }
+    
+    // MARK: Decodable Object Response
+    
+    /// Creates a request publisher which fetches raw data from an endpoint and decodes it.
+    /// Returns a `URLSessionTask`, which allows for cancellation and retries.
+    /// - Parameter url: The URL for the request. Accepts a URL or a String.
+    /// - Parameter method: The HTTP method for the request. Defaults to `GET`.
+    /// - Parameter parameters: The parameters to be converted into a String-keyed dictionary to send in the query string or HTTP body.
+    /// - Parameter headers: The HTTP headers to send with the request.
+    /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
+    /// - Parameter decoder: The `JSONDecoder` to use when decoding the response data.
+    /// - Returns: A publisher that wraps a data task for the URL.
     func requestPublisher<T: Decodable>(_ url: URLConvertible,
-                                        method: HTTPMethod,
-                                        parameters: [String: Any]? = nil,
+                                        method: HTTPMethod = .get,
+                                        parameters: ParameterDictionaryConvertible? = nil,
                                         headers: HTTPHeaderDictionaryConvertible? = nil,
                                         encoding: ParameterEncoding? = nil,
                                         decoder: JSONDecoder = JSONDecoder()) -> AnyPublisher<T, Error> {
@@ -74,5 +116,29 @@ extension HTTPClient {
                 }
             }
             .eraseToAnyPublisher()
+    }
+    
+    /// Creates a request publisher which fetches raw data from an endpoint and decodes it.
+    /// Returns a `URLSessionTask`, which allows for cancellation and retries.
+    /// - Parameter url: The URL for the request. Accepts a URL or a String.
+    /// - Parameter method: The HTTP method for the request. Defaults to `GET`.
+    /// - Parameter parameters: The `Encodable` object to be converted into a String-keyed dictionary to send in the query string or HTTP body.
+    /// - Parameter headers: The HTTP headers to send with the request.
+    /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
+    /// - Parameter decoder: The `JSONDecoder` to use when decoding the response data.
+    /// - Returns: A publisher that wraps a data task for the URL.
+    // swiftlint:disable:next function_default_parameter_at_end
+    func requestPublisher<T: Decodable>(_ url: URLConvertible,
+                                        method: HTTPMethod = .get,
+                                        parameters: Encodable,
+                                        headers: HTTPHeaderDictionaryConvertible? = nil,
+                                        encoding: ParameterEncoding? = nil,
+                                        decoder: JSONDecoder = JSONDecoder()) -> AnyPublisher<T, Error> {
+        return self.requestPublisher(url,
+                                     method: method,
+                                     parameters: try? parameters.asDictionary(),
+                                     headers: headers,
+                                     encoding: encoding,
+                                     decoder: decoder)
     }
 }

--- a/Sources/UtilityBeltNetworking/HTTPClient.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient.swift
@@ -43,7 +43,6 @@ public class HTTPClient {
     // MARK: Data Response
     
     /// Creates and sends a request which fetches raw data from an endpoint.
-    /// Returns a `URLSessionTask`, which allows for cancellation and retries.
     /// - Parameter url: The URL for the request. Accepts a URL or a String.
     /// - Parameter method: The HTTP method for the request. Defaults to `GET`.
     /// - Parameter parameters: The parameters to be converted into a String-keyed dictionary to send in the query string or HTTP body.
@@ -141,7 +140,6 @@ public class HTTPClient {
     }
     
     /// Creates and sends a request which fetches raw data from an endpoint.
-    /// Returns a `URLSessionTask`, which allows for cancellation and retries.
     /// - Parameter url: The URL for the request. Accepts a URL or a String.
     /// - Parameter method: The HTTP method for the request. Defaults to `GET`.
     /// - Parameter parameters: The `Encodable` object to be converted into a String-keyed dictionary to send in the query string or HTTP body.
@@ -168,7 +166,6 @@ public class HTTPClient {
     // MARK: Decodable Object Response
     
     /// Creates and sends a request which fetches raw data from an endpoint and decodes it.
-    /// Returns a `URLSessionTask`, which allows for cancellation and retries.
     /// - Parameter url: The URL for the request. Accepts a URL or a String.
     /// - Parameter method: The HTTP method for the request. Defaults to `GET`.
     /// - Parameter parameters: The parameters to be converted into a String-keyed dictionary to send in the query string or HTTP body.
@@ -234,7 +231,6 @@ public class HTTPClient {
     }
     
     /// Creates and sends a request which fetches raw data from an endpoint and decodes it.
-    /// Returns a `URLSessionTask`, which allows for cancellation and retries.
     /// - Parameter url: The URL for the request. Accepts a URL or a String.
     /// - Parameter method: The HTTP method for the request. Defaults to `GET`.
     /// - Parameter parameters: The `Encodable` object to be converted into a String-keyed dictionary to send in the query string or HTTP body.

--- a/Sources/UtilityBeltNetworking/HTTPClient.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient.swift
@@ -40,18 +40,20 @@ public class HTTPClient {
         self.session = session
     }
     
-    /// Creates and sends a request, fetching raw data from an endpoint.
+    // MARK: Data Response
+    
+    /// Creates and sends a request which fetches raw data from an endpoint.
     /// Returns a `URLSessionTask`, which allows for cancellation and retries.
     /// - Parameter url: The URL for the request. Accepts a URL or a String.
-    /// - Parameter method: The HTTP method for the request.
-    /// - Parameter parameters: The dictionary of parameters to send in the query string or HTTP body.
-    /// - Parameter headers: The HTTP headers to be with the request.
-    /// - Parameter encoding: The parameter encoding method. If nil, uses default for HTTP method.
+    /// - Parameter method: The HTTP method for the request. Defaults to `GET`.
+    /// - Parameter parameters: The parameters to be converted into a String-keyed dictionary to send in the query string or HTTP body.
+    /// - Parameter headers: The HTTP headers to send with the request.
+    /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
     /// - Parameter completion: The completion block to call when the request is completed.
     @discardableResult
     public func request(_ url: URLConvertible,
-                        method: HTTPMethod,
-                        parameters: [String: Any]? = nil,
+                        method: HTTPMethod = .get,
+                        parameters: ParameterDictionaryConvertible? = nil,
                         headers: HTTPHeaderDictionaryConvertible? = nil,
                         encoding: ParameterEncoding? = nil,
                         completion: DataTaskCompletion? = nil) -> URLSessionTask? {
@@ -137,19 +139,45 @@ public class HTTPClient {
         return task
     }
     
-    /// Creates and sends a request, fetching raw data from an endpoint that is decoded into a Decodable object.
+    /// Creates and sends a request which fetches raw data from an endpoint.
     /// Returns a `URLSessionTask`, which allows for cancellation and retries.
     /// - Parameter url: The URL for the request. Accepts a URL or a String.
-    /// - Parameter method: The HTTP method for the request.
-    /// - Parameter parameters: The dictionary of parameters to send in the query string or HTTP body.
-    /// - Parameter headers: The HTTP headers to be with the request.
-    /// - Parameter encoding: The parameter encoding method. If nil, uses default for HTTP method.
-    /// - Parameter jsonDecoder: The `JSONDecoder` to use when decoding the response data.
+    /// - Parameter method: The HTTP method for the request. Defaults to `GET`.
+    /// - Parameter parameters: The `Encodable` object to be converted into a String-keyed dictionary to send in the query string or HTTP body.
+    /// - Parameter headers: The HTTP headers to send with the request.
+    /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
+    /// - Parameter completion: The completion block to call when the request is completed.
+    @discardableResult
+    // swiftlint:disable:next function_default_parameter_at_end
+    public func request(_ url: URLConvertible,
+                        method: HTTPMethod = .get,
+                        parameters: Encodable,
+                        headers: HTTPHeaderDictionaryConvertible? = nil,
+                        encoding: ParameterEncoding? = nil,
+                        completion: DataTaskCompletion? = nil) -> URLSessionTask? {
+        self.request(url,
+                     method: method,
+                     parameters: try? parameters.asDictionary(),
+                     headers: headers,
+                     encoding: encoding,
+                     completion: completion)
+    }
+    
+    // MARK: Decodable Object Response
+    
+    /// Creates and sends a request which fetches raw data from an endpoint and decodes it.
+    /// Returns a `URLSessionTask`, which allows for cancellation and retries.
+    /// - Parameter url: The URL for the request. Accepts a URL or a String.
+    /// - Parameter method: The HTTP method for the request. Defaults to `GET`.
+    /// - Parameter parameters: The parameters to be converted into a String-keyed dictionary to send in the query string or HTTP body.
+    /// - Parameter headers: The HTTP headers to send with the request.
+    /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
+    /// - Parameter decoder: The `JSONDecoder` to use when decoding the response data.
     /// - Parameter completion: The completion block to call when the request is completed.
     @discardableResult
     public func request<T: Decodable>(_ url: URLConvertible,
-                                      method: HTTPMethod,
-                                      parameters: [String: Any]? = nil,
+                                      method: HTTPMethod = .get,
+                                      parameters: ParameterDictionaryConvertible? = nil,
                                       headers: HTTPHeaderDictionaryConvertible? = nil,
                                       encoding: ParameterEncoding? = nil,
                                       decoder: JSONDecoder = JSONDecoder(),
@@ -202,15 +230,44 @@ public class HTTPClient {
         }
     }
     
+    /// Creates and sends a request which fetches raw data from an endpoint and decodes it.
+    /// Returns a `URLSessionTask`, which allows for cancellation and retries.
+    /// - Parameter url: The URL for the request. Accepts a URL or a String.
+    /// - Parameter method: The HTTP method for the request. Defaults to `GET`.
+    /// - Parameter parameters: The `Encodable` object to be converted into a String-keyed dictionary to send in the query string or HTTP body.
+    /// - Parameter headers: The HTTP headers to send with the request.
+    /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
+    /// - Parameter decoder: The `JSONDecoder` to use when decoding the response data.
+    /// - Parameter completion: The completion block to call when the request is completed.
+    @discardableResult
+    // swiftlint:disable:next function_default_parameter_at_end
+    public func request<T: Decodable>(_ url: URLConvertible,
+                                      method: HTTPMethod = .get,
+                                      parameters: Encodable,
+                                      headers: HTTPHeaderDictionaryConvertible? = nil,
+                                      encoding: ParameterEncoding? = nil,
+                                      decoder: JSONDecoder = JSONDecoder(),
+                                      completion: DecodableTaskCompletion<T>? = nil) -> URLSessionTask? {
+        self.request(url,
+                     method: method,
+                     parameters: try? parameters.asDictionary(),
+                     headers: headers,
+                     encoding: encoding,
+                     decoder: decoder,
+                     completion: completion)
+    }
+    
+    // MARK: URL Request Configuration
+    
     /// Creates a configured URLRequest.
     /// - Parameter url: The URL for the request. Accepts a URL or a String.
-    /// - Parameter method: The HTTP method for the request.
-    /// - Parameter parameters: The dictionary of parameters to send in the query string or HTTP body.
-    /// - Parameter headers: The HTTP headers to be with the request.
-    /// - Parameter encoding: The parameter encoding method. If nil, uses default for HTTP method.
+    /// - Parameter method: The HTTP method for the request. Defaults to `GET`.
+    /// - Parameter parameters: The parameters to be converted into a String-keyed dictionary to send in the query string or HTTP body.
+    /// - Parameter headers: The HTTP headers to send with the request.
+    /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
     func configuredURLRequest(url: URLConvertible,
-                              method: HTTPMethod,
-                              parameters: [String: Any]? = nil,
+                              method: HTTPMethod = .get,
+                              parameters: ParameterDictionaryConvertible? = nil,
                               headers: HTTPHeaderDictionaryConvertible? = nil,
                               encoding: ParameterEncoding? = nil) throws -> URLRequest {
         let url = try url.asURL()

--- a/Sources/UtilityBeltNetworking/HTTPClient.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient.swift
@@ -50,6 +50,7 @@ public class HTTPClient {
     /// - Parameter headers: The HTTP headers to send with the request.
     /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
     /// - Parameter completion: The completion block to call when the request is completed.
+    /// - Returns: The `URLSessionTask` for the request.
     @discardableResult
     public func request(_ url: URLConvertible,
                         method: HTTPMethod = .get,
@@ -147,6 +148,7 @@ public class HTTPClient {
     /// - Parameter headers: The HTTP headers to send with the request.
     /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
     /// - Parameter completion: The completion block to call when the request is completed.
+    /// - Returns: The `URLSessionTask` for the request.
     @discardableResult
     // swiftlint:disable:next function_default_parameter_at_end
     public func request(_ url: URLConvertible,
@@ -174,6 +176,7 @@ public class HTTPClient {
     /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
     /// - Parameter decoder: The `JSONDecoder` to use when decoding the response data.
     /// - Parameter completion: The completion block to call when the request is completed.
+    /// - Returns: The `URLSessionTask` for the request.
     @discardableResult
     public func request<T: Decodable>(_ url: URLConvertible,
                                       method: HTTPMethod = .get,
@@ -239,6 +242,7 @@ public class HTTPClient {
     /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
     /// - Parameter decoder: The `JSONDecoder` to use when decoding the response data.
     /// - Parameter completion: The completion block to call when the request is completed.
+    /// - Returns: The `URLSessionTask` for the request.
     @discardableResult
     // swiftlint:disable:next function_default_parameter_at_end
     public func request<T: Decodable>(_ url: URLConvertible,
@@ -265,6 +269,7 @@ public class HTTPClient {
     /// - Parameter parameters: The parameters to be converted into a String-keyed dictionary to send in the query string or HTTP body.
     /// - Parameter headers: The HTTP headers to send with the request.
     /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
+    /// - Returns: The configured `URLRequest` object.
     func configuredURLRequest(url: URLConvertible,
                               method: HTTPMethod = .get,
                               parameters: ParameterDictionaryConvertible? = nil,

--- a/Sources/UtilityBeltNetworking/Protocols/ParameterDictionaryConvertible.swift
+++ b/Sources/UtilityBeltNetworking/Protocols/ParameterDictionaryConvertible.swift
@@ -1,0 +1,17 @@
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
+
+public protocol ParameterDictionaryConvertible {
+    func asParameterDictionary() -> [String: Any]?
+}
+
+public extension ParameterDictionaryConvertible where Self: Encodable {
+    func asParameterDictionary() -> [String: Any]? {
+        return try? self.asDictionary()
+    }
+}
+
+extension Dictionary: ParameterDictionaryConvertible where Key == String, Value == Any {
+    public func asParameterDictionary() -> [String: Any]? {
+        return self
+    }
+}


### PR DESCRIPTION
**Issue Link**
IOS-1943

**Description**
This PR updates our `HTTPClient` to allow conformance to `ParameterConvertible` and adds convenience methods for passing `Encodable` types by default.

I can't think of a clean way of doing `extension Encodable: ParameterConvertible { ... }` (which doesn't work, but if anyone has a better idea I'm open to it! Would love to not have the convenience methods.

Also updated a bunch of documentation.
