### PR TITLE
IOS-1969: Feature/Add timeout property to HTTPClient

### DIFF
--- a/Sources/UtilityBeltNetworking/HTTPClient.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient.swift
@@ -29,6 +29,13 @@ public class HTTPClient {
         #endif
     }()
     
+    /// The timeout interval to use when waiting for additional data. When the request timer reaches the specified interval without receiving
+    /// any new data, it triggers a timeout. If this property is set to `nil`, this property is ignored and the default value of 60 seconds is used.
+    ///
+    /// The value can be overridden by the session configuration if the session configuration `timeoutIntervalForRequest` property is
+    /// set to be more restrictive. https://stackoverflow.com/a/54806389
+    public var timeoutInterval: TimeInterval?
+    
     // MARK: - Methods
     
     // MARK: Initializers
@@ -274,6 +281,10 @@ public class HTTPClient {
         
         var request = URLRequest(url: url)
         request.httpMethod = method.rawValue
+        
+        if let timeoutInterval = self.timeoutInterval {
+            request.timeoutInterval = timeoutInterval
+        }
         
         request.setHeaders(headers)
         

--- a/Tests/UtilityBeltNetworkingTests/Tests/HTTPClientTests.swift
+++ b/Tests/UtilityBeltNetworkingTests/Tests/HTTPClientTests.swift
@@ -1,0 +1,51 @@
+// Copyright © 2020 SpotHero, Inc. All rights reserved.
+
+import Foundation
+@testable import UtilityBeltNetworking
+import XCTest
+
+final class HTTPClientTests: XCTestCase {
+    func testNilTimeoutIntervalValue() throws {
+        let client = HTTPClient.shared
+        client.timeoutInterval = nil
+        
+        // The timeout interval should be nil.
+        XCTAssertNil(client.timeoutInterval)
+        
+        // A request is made on an HTTPClient with no timeout set.
+        let request = try client.createSimpleTestRequest()
+        
+        // The timeout on the request should be the default value of 60 seconds.
+        XCTAssertEqual(request.timeoutInterval, 60)
+    }
+    
+    func testCustomTimeoutIntervalValue() throws {
+        // An HTTP client is created.
+        let client = HTTPClient.shared
+        
+        // The timeout is set on the client.
+        let timeout = TimeInterval(1)
+        client.timeoutInterval = timeout
+        
+        // A request is made on the HTTPClient.
+        let request = try client.createSimpleTestRequest()
+        
+        // The timeout interval on the request should be the same as the timeout.
+        XCTAssertEqual(request.timeoutInterval, timeout)
+    }
+}
+
+private extension HTTPClient {
+    // Creates a simple URL request.
+    func createSimpleTestRequest() throws -> URLRequest {
+        let url = try XCTUnwrap("https://www.spothero.com".asURL())
+        let request = try self.configuredURLRequest(
+            url: url,
+            method: .get,
+            parameters: nil,
+            headers: nil,
+            encoding: nil
+        )
+        return request
+    }
+}


### PR DESCRIPTION
**Issue Link**
IOS-1969

**Description**
Adds a `timeoutInterval` property on the HTTPClient.
