### PR TITLE
IOS-2591: bugfix/threading issues on save and merge

### DIFF
--- a/Sources/UtilityBeltData/CoreData/CoreDataOperator.swift
+++ b/Sources/UtilityBeltData/CoreData/CoreDataOperator.swift
@@ -332,8 +332,11 @@ public class CoreDataOperator {
         context.perform {
             // Save the child context. This will push changes up to the parent.
             try? context.save()
-            // Save the parent context. This will push changes to the persistent store.
-            try? mainContext.save()
+            
+            mainContext.perform {
+                // Save the parent context. This will push changes to the persistent store.
+                try? mainContext.save()
+            }
         }
     }
 }


### PR DESCRIPTION
**JIRA Ticket**
https://spothero.atlassian.net/browse/IOS-2591

**Description**
Discovered an issue where we were performing a save and merge operation all on the same queue - the child Managed Object Context's private background queue.

Because the main context is a main queue MOC and Core Data MOCs are not thread safe, this will lead to a crash.

I've updated this to ensure the main context operations are perform on its own queue by using the `perform` block to do the save.