### PR TITLE
IOS-2695: Feature/Core Data Config for XCUITesting

### DIFF
--- a/Sources/UtilityBeltUITesting/Models/CoreDataConfiguration.swift
+++ b/Sources/UtilityBeltUITesting/Models/CoreDataConfiguration.swift
@@ -1,0 +1,19 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+/// Struct that provides information that the main target should use to configure Core Data.
+public struct CoreDataConfiguration: LaunchEnvironmentCodable {
+    // MARK: Properties
+    
+    public static let launchEnvironmentKey = "core-data-configuration"
+    
+    /// The URL of the Core Data database to use.
+    public let databaseURL: URL
+    
+    // MARK: Initialization
+    
+    public init(databaseURL: URL) {
+        self.databaseURL = databaseURL
+    }
+}


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-2695

**Description**
Added a configuration object that allows the passing of a database URL into the main app target.