### PR TITLE
IOS-2697: Feature/UserDefaults XCUI Injection

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -80,7 +80,7 @@ let package = Package(
         .testTarget(
             name: "UtilityBeltUITestingTests",
             dependencies: [
-                .target(name: "UtilityBeltUITesting")
+                .target(name: "UtilityBeltUITesting"),
             ]
         ),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -77,6 +77,12 @@ let package = Package(
                 .target(name: "UtilityBeltNetworking"),
             ]
         ),
+        .testTarget(
+            name: "UtilityBeltUITestingTests",
+            dependencies: [
+                .target(name: "UtilityBeltUITesting")
+            ]
+        ),
     ],
     swiftLanguageVersions: [
         .v5,

--- a/Sources/UtilityBeltUITesting/Extensions/UserDefaultsConfiguration+UserDefaults.swift
+++ b/Sources/UtilityBeltUITesting/Extensions/UserDefaultsConfiguration+UserDefaults.swift
@@ -6,14 +6,32 @@ public extension UserDefaultsConfiguration {
     /// Injects the configuration into the appropriate `UserDefaults`.
     func injectIntoUserDefaults() {
         for object in self.standard {
-            UserDefaults.standard.setValue(object.value, forKey: object.key)
+            self.storeObject(object, in: UserDefaults.standard)
         }
         
         for (suiteName, objects) in self.customSuites {
-            let defaults = UserDefaults(suiteName: suiteName)
-            for object in objects {
-                defaults?.setValue(object.value, forKey: object.key)
+            guard let defaults = UserDefaults(suiteName: suiteName) else {
+                continue
             }
+            
+            for object in objects {
+                self.storeObject(object, in: defaults)
+            }
+        }
+    }
+    
+    private func storeObject(_ object: UserDefaultsObject, in userDefaults: UserDefaults) {
+        switch object.value {
+        case let .bool(value):
+            userDefaults.setValue(value, forKey: object.key)
+        case let .data(value):
+            userDefaults.setValue(value, forKey: object.key)
+        case let .date(value):
+            userDefaults.setValue(value, forKey: object.key)
+        case let .int(value):
+            userDefaults.setValue(value, forKey: object.key)
+        case let .string(value):
+            userDefaults.setValue(value, forKey: object.key)
         }
     }
 }

--- a/Sources/UtilityBeltUITesting/Extensions/UserDefaultsConfiguration+UserDefaults.swift
+++ b/Sources/UtilityBeltUITesting/Extensions/UserDefaultsConfiguration+UserDefaults.swift
@@ -28,9 +28,15 @@ public extension UserDefaultsConfiguration {
             userDefaults.setValue(value, forKey: object.key)
         case let .date(value):
             userDefaults.setValue(value, forKey: object.key)
+        case let .double(value):
+            userDefaults.setValue(value, forKey: object.key)
+        case let .float(value):
+            userDefaults.setValue(value, forKey: object.key)
         case let .int(value):
             userDefaults.setValue(value, forKey: object.key)
         case let .string(value):
+            userDefaults.setValue(value, forKey: object.key)
+        case let .uint(value):
             userDefaults.setValue(value, forKey: object.key)
         }
     }

--- a/Sources/UtilityBeltUITesting/Extensions/UserDefaultsConfiguration+UserDefaults.swift
+++ b/Sources/UtilityBeltUITesting/Extensions/UserDefaultsConfiguration+UserDefaults.swift
@@ -1,0 +1,19 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+public extension UserDefaultsConfiguration {
+    /// Injects the configuration into the appropriate `UserDefaults`.
+    func injectIntoUserDefaults() {
+        for object in self.standard {
+            UserDefaults.standard.setValue(object.value, forKey: object.key)
+        }
+        
+        for (suiteName, objects) in self.customSuites {
+            let defaults = UserDefaults(suiteName: suiteName)
+            for object in objects {
+                defaults?.setValue(object.value, forKey: object.key)
+            }
+        }
+    }
+}

--- a/Sources/UtilityBeltUITesting/Models/UserDefaultsConfiguration.swift
+++ b/Sources/UtilityBeltUITesting/Models/UserDefaultsConfiguration.swift
@@ -3,79 +3,37 @@
 import Foundation
 
 public final class UserDefaultsConfiguration: LaunchEnvironmentCodable {
-    // MARK: CodingKeys
-    
-    private enum CodingKeys: CodingKey {
-        case standardDictionaryData
-        case customSuitesDictionaryData
-    }
-    
     // MARK: Properties
     
     public static let launchEnvironmentKey = "user-defaults-configuration"
     
-    /// A dictionary represent key/value pairs to be written to the `.standard` UserDefaults.
-    public private(set) var standardDictionary: [String: Any] = [:]
+    /// An array representing key/value pairs to be written to the `.standard` UserDefaults.
+    public private(set) var standard: [UserDefaultsObject] = []
     
-    /// A dictionary represent key/value pairs to be written to UserDefaults where the
+    /// A dictionary representing key/value pairs to be written to UserDefaults where the
     /// top-level key is the name of the suite, and the value is a dictionary of UserDefaults.
-    public private(set) var customSuitesDictionary: [String: [String: Any]] = [:]
+    public private(set) var customSuites: [String: [UserDefaultsObject]] = [:]
     
     // MARK: Storing UserDefaults
     
-    /// Stores a value for the given key in the standard UserDefaults dictionary.
-    public func storeValue(_ value: Any, forKey key: String) {
-        self.standardDictionary[key] = value
+    /// Stores the `UserDefaultsObject` for use in `UserDefaults.standard`.
+    public func storeUserDefaultsObject(_ object: UserDefaultsObject) {
+        self.standard.removeAll(where: { $0.key == object.key })
+        self.standard.append(object)
     }
-    
-    /// Stores a value for the given key in a dictionary under the given suite name.
-    public func storeValue(_ value: Any, forKey key: String, inSuite suite: String) {
-        if self.customSuitesDictionary[suite] == nil {
-            self.customSuitesDictionary[suite] = [:]
+
+    /// Stores a value `UserDefaultsObject` in an array under the given suite name.
+    public func storeUserDefaultsObject(_ object: UserDefaultsObject, inSuite suite: String) {
+        if self.customSuites[suite] == nil {
+            self.customSuites[suite] = []
         }
-        
-        self.customSuitesDictionary[suite]?[key] = value
+
+        self.customSuites[suite]?.removeAll(where: { $0.key == object.key })
+
+        self.customSuites[suite]?.append(object)
     }
    
-    // MARK: Decodable
+    // MARK: Initialization
     
     public init() {}
-    
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        let standardDictionaryData = try container.decode(Data.self, forKey: .standardDictionaryData)
-        let standardDictionaryJSON = try JSONSerialization.jsonObject(with: standardDictionaryData, options: [])
-        guard let standardDictionary = standardDictionaryJSON as? [String: Any] else {
-            let debugDescription = "Value for .standardDictionaryData could not be cast to [String: Any]."
-            throw DecodingError.dataCorruptedError(forKey: .standardDictionaryData,
-                                                   in: container,
-                                                   debugDescription: debugDescription)
-        }
-        self.standardDictionary = standardDictionary
-        
-        let customSuitesDictionaryData = try container.decode(Data.self, forKey: .customSuitesDictionaryData)
-        let customSuitesDictionaryJSON = try JSONSerialization.jsonObject(with: customSuitesDictionaryData, options: [])
-        guard let customSuitesDictionary = customSuitesDictionaryJSON as? [String: [String: Any]] else {
-            let debugDescription = "Value for .customSuitesDictionaryData could not be cast to [String: [String: Any]]."
-            throw DecodingError.dataCorruptedError(forKey: .customSuitesDictionaryData,
-                                                   in: container,
-                                                   debugDescription: debugDescription)
-        }
-        self.customSuitesDictionary = customSuitesDictionary
-    }
-    
-    // MARK: Encodable
-    
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        
-        let standardDictionaryData = try JSONSerialization.data(withJSONObject: self.standardDictionary,
-                                                                options: [])
-        try container.encode(standardDictionaryData, forKey: .standardDictionaryData)
-        
-        let customSuitesDictionaryData = try JSONSerialization.data(withJSONObject: self.customSuitesDictionary,
-                                                                    options: [])
-        try container.encode(customSuitesDictionaryData, forKey: .customSuitesDictionaryData)
-    }
 }

--- a/Sources/UtilityBeltUITesting/Models/UserDefaultsConfiguration.swift
+++ b/Sources/UtilityBeltUITesting/Models/UserDefaultsConfiguration.swift
@@ -44,15 +44,25 @@ public final class UserDefaultsConfiguration: LaunchEnvironmentCodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let standardDictionaryData = try container.decode(Data.self,
-                                                          forKey: .standardDictionaryData)
-        self.standardDictionary = try JSONSerialization
-            .jsonObject(with: standardDictionaryData, options: []) as? [String: Any] ?? [:]
+        let standardDictionaryData = try container.decode(Data.self, forKey: .standardDictionaryData)
+        let standardDictionaryJSON = try JSONSerialization.jsonObject(with: standardDictionaryData, options: [])
+        guard let standardDictionary = standardDictionaryJSON as? [String: Any] else {
+            let debugDescription = "Value for .standardDictionaryData could not be cast to [String: Any]."
+            throw DecodingError.dataCorruptedError(forKey: .standardDictionaryData,
+                                                   in: container,
+                                                   debugDescription: debugDescription)
+        }
+        self.standardDictionary = standardDictionary
         
-        let customSuitesDictionaryData = try container.decode(Data.self,
-                                                              forKey: .customSuitesDictionaryData)
-        self.customSuitesDictionary = try JSONSerialization
-            .jsonObject(with: customSuitesDictionaryData, options: []) as? [String: [String: Any]] ?? [:]
+        let customSuitesDictionaryData = try container.decode(Data.self, forKey: .customSuitesDictionaryData)
+        let customSuitesDictionaryJSON = try JSONSerialization.jsonObject(with: customSuitesDictionaryData, options: [])
+        guard let customSuitesDictionary = customSuitesDictionaryJSON as? [String: [String: Any]] else {
+            let debugDescription = "Value for .customSuitesDictionaryData could not be cast to [String: [String: Any]]."
+            throw DecodingError.dataCorruptedError(forKey: .customSuitesDictionaryData,
+                                                   in: container,
+                                                   debugDescription: debugDescription)
+        }
+        self.customSuitesDictionary = customSuitesDictionary
     }
     
     // MARK: Encodable

--- a/Sources/UtilityBeltUITesting/Models/UserDefaultsConfiguration.swift
+++ b/Sources/UtilityBeltUITesting/Models/UserDefaultsConfiguration.swift
@@ -3,7 +3,16 @@
 import Foundation
 
 public final class UserDefaultsConfiguration: LaunchEnvironmentCodable {
+    // MARK: CodingKeys
+    
+    private enum CodingKeys: CodingKey {
+        case standardDictionaryData
+        case customSuitesDictionaryData
+    }
+    
     // MARK: Properties
+    
+    public static let launchEnvironmentKey = "user-defaults-configuration"
     
     /// A dictionary represent key/value pairs to be written to the `.standard` UserDefaults.
     public private(set) var standardDictionary: [String: Any] = [:]
@@ -26,5 +35,35 @@ public final class UserDefaultsConfiguration: LaunchEnvironmentCodable {
         }
         
         self.customSuitesDictionary[suite]?[key] = value
+    }
+   
+    // MARK: Decodable
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let standardDictionaryData = try container.decode(Data.self,
+                                                          forKey: .standardDictionaryData)
+        self.standardDictionary = try JSONSerialization
+            .jsonObject(with: standardDictionaryData, options: []) as? [String: Any] ?? [:]
+        
+        let customSuitesDictionaryData = try container.decode(Data.self,
+                                                              forKey: .customSuitesDictionaryData)
+        self.customSuitesDictionary = try JSONSerialization
+            .jsonObject(with: customSuitesDictionaryData, options: []) as? [String: [String: Any]] ?? [:]
+    }
+    
+    // MARK: Encodable
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        let standardDictionaryData = try JSONSerialization.data(withJSONObject: self.standardDictionary,
+                                                                options: [])
+        try container.encode(standardDictionaryData, forKey: .standardDictionaryData)
+        
+        let customSuitesDictionaryData = try JSONSerialization.data(withJSONObject: self.customSuitesDictionary,
+                                                                    options: [])
+        try container.encode(customSuitesDictionaryData, forKey: .customSuitesDictionaryData)
     }
 }

--- a/Sources/UtilityBeltUITesting/Models/UserDefaultsConfiguration.swift
+++ b/Sources/UtilityBeltUITesting/Models/UserDefaultsConfiguration.swift
@@ -1,0 +1,30 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+public final class UserDefaultsConfiguration: LaunchEnvironmentCodable {
+    // MARK: Properties
+    
+    /// A dictionary represent key/value pairs to be written to the `.standard` UserDefaults.
+    public private(set) var standardDictionary: [String: Any] = [:]
+    
+    /// A dictionary represent key/value pairs to be written to UserDefaults where the
+    /// top-level key is the name of the suite, and the value is a dictionary of UserDefaults.
+    public private(set) var customSuitesDictionary: [String: [String: Any]] = [:]
+    
+    // MARK: Storing UserDefaults
+    
+    /// Stores a value for the given key in the standard UserDefaults dictionary.
+    public func storeValue(_ value: Any, forKey key: String) {
+        self.standardDictionary[key] = value
+    }
+    
+    /// Stores a value for the given key in a dictionary under the given suite name.
+    public func storeValue(_ value: Any, forKey key: String: inSuite suite: String) {
+        if self.customSuitesDictionary[suite] == nil {
+            self.customSuitesDictionary[suite] = [:]
+        }
+        
+        self.customSuitesDictionary[suite]?[key] = value
+    }
+}

--- a/Sources/UtilityBeltUITesting/Models/UserDefaultsConfiguration.swift
+++ b/Sources/UtilityBeltUITesting/Models/UserDefaultsConfiguration.swift
@@ -39,6 +39,8 @@ public final class UserDefaultsConfiguration: LaunchEnvironmentCodable {
    
     // MARK: Decodable
     
+    public init() {}
+    
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 

--- a/Sources/UtilityBeltUITesting/Models/UserDefaultsConfiguration.swift
+++ b/Sources/UtilityBeltUITesting/Models/UserDefaultsConfiguration.swift
@@ -20,7 +20,7 @@ public final class UserDefaultsConfiguration: LaunchEnvironmentCodable {
     }
     
     /// Stores a value for the given key in a dictionary under the given suite name.
-    public func storeValue(_ value: Any, forKey key: String: inSuite suite: String) {
+    public func storeValue(_ value: Any, forKey key: String, inSuite suite: String) {
         if self.customSuitesDictionary[suite] == nil {
             self.customSuitesDictionary[suite] = [:]
         }

--- a/Sources/UtilityBeltUITesting/Models/UserDefaultsObject.swift
+++ b/Sources/UtilityBeltUITesting/Models/UserDefaultsObject.swift
@@ -33,6 +33,7 @@ public extension UserDefaultsObject {
             case date
             case int
             case object
+            case string
         }
         
         // MARK: Cases
@@ -40,6 +41,8 @@ public extension UserDefaultsObject {
         case date(Date)
         case int(Int)
         indirect case object(UserDefaultsObject)
+        case string(String)
+        
         case `nil`
         
         // MARK: Decoding
@@ -57,6 +60,9 @@ public extension UserDefaultsObject {
             case .object:
                 let value = try container.decode(UserDefaultsObject.self, forKey: .object)
                 self = .object(value)
+            case .string:
+                let value = try container.decode(String.self, forKey: .string)
+                self = .string(value)
             case nil:
                 self = .nil
             }
@@ -74,6 +80,8 @@ public extension UserDefaultsObject {
                 try container.encode(value, forKey: .int)
             case let .object(value):
                 try container.encode(value, forKey: .object)
+            case let .string(value):
+                try container.encode(value, forKey: .string)
             case .nil:
                 break
             }

--- a/Sources/UtilityBeltUITesting/Models/UserDefaultsObject.swift
+++ b/Sources/UtilityBeltUITesting/Models/UserDefaultsObject.swift
@@ -30,6 +30,7 @@ public extension UserDefaultsObject {
         // MARK: CodingKeys
         
         enum CodingKeys: String, CodingKey {
+            case bool
             case date
             case int
             case object
@@ -38,6 +39,7 @@ public extension UserDefaultsObject {
         
         // MARK: Cases
         
+        case bool(Bool)
         case date(Date)
         case int(Int)
         indirect case object(UserDefaultsObject)
@@ -51,6 +53,9 @@ public extension UserDefaultsObject {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             
             switch container.allKeys.first {
+            case .bool:
+                let value = try container.decode(Bool.self, forKey: .bool)
+                self = .bool(value)
             case .date:
                 let value = try container.decode(Date.self, forKey: .date)
                 self = .date(value)
@@ -74,6 +79,8 @@ public extension UserDefaultsObject {
             var container = encoder.container(keyedBy: CodingKeys.self)
             
             switch self {
+            case let .bool(value):
+                try container.encode(value, forKey: .bool)
             case let .date(value):
                 try container.encode(value, forKey: .date)
             case let .int(value):

--- a/Sources/UtilityBeltUITesting/Models/UserDefaultsObject.swift
+++ b/Sources/UtilityBeltUITesting/Models/UserDefaultsObject.swift
@@ -33,8 +33,11 @@ public extension UserDefaultsObject {
             case bool
             case data
             case date
+            case double
+            case float
             case int
             case string
+            case uint
         }
         
         // MARK: Cases
@@ -42,8 +45,11 @@ public extension UserDefaultsObject {
         case bool(Bool)
         case data(Data)
         case date(Date)
+        case double(Double)
+        case float(Float)
         case int(Int)
         case string(String)
+        case uint(UInt)
         
         // MARK: Decoding
         
@@ -67,12 +73,21 @@ public extension UserDefaultsObject {
             case .date:
                 let value = try container.decode(Date.self, forKey: .date)
                 self = .date(value)
+            case .double:
+                let value = try container.decode(Double.self, forKey: .double)
+                self = .double(value)
+            case .float:
+                let value = try container.decode(Float.self, forKey: .float)
+                self = .float(value)
             case .int:
                 let value = try container.decode(Int.self, forKey: .int)
                 self = .int(value)
             case .string:
                 let value = try container.decode(String.self, forKey: .string)
                 self = .string(value)
+            case .uint:
+                let value = try container.decode(UInt.self, forKey: .uint)
+                self = .uint(value)
             }
         }
         
@@ -88,10 +103,16 @@ public extension UserDefaultsObject {
                 try container.encode(value, forKey: .data)
             case let .date(value):
                 try container.encode(value, forKey: .date)
+            case let .double(value):
+                try container.encode(value, forKey: .double)
+            case let .float(value):
+                try container.encode(value, forKey: .float)
             case let .int(value):
                 try container.encode(value, forKey: .int)
             case let .string(value):
                 try container.encode(value, forKey: .string)
+            case let .uint(value):
+                try container.encode(value, forKey: .uint)
             }
         }
     }
@@ -102,16 +123,22 @@ public extension UserDefaultsObject {
 extension UserDefaultsObject.Value: Equatable {
     public static func == (lhs: UserDefaultsObject.Value, rhs: UserDefaultsObject.Value) -> Bool {
         switch (lhs, rhs) {
-        case let (.bool(leftBool), .bool(rightBool)):
-            return leftBool == rightBool
-        case let (.date(leftDate), .date(rightDate)):
-            return leftDate == rightDate
-        case let (.data(leftData), .data(rightData)):
-            return leftData == rightData
-        case let (.int(leftInt), .int(rightInt)):
-            return leftInt == rightInt
-        case let (.string(leftString), .string(rightString)):
-            return leftString == rightString
+        case let (.bool(leftValue), .bool(rightValue)):
+            return leftValue == rightValue
+        case let (.date(leftValue), .date(rightValue)):
+            return leftValue == rightValue
+        case let (.data(leftValue), .data(rightValue)):
+            return leftValue == rightValue
+        case let (.double(leftValue), .double(rightValue)):
+            return leftValue == rightValue
+        case let (.float(leftValue), .float(rightValue)):
+            return leftValue == rightValue
+        case let (.int(leftValue), .int(rightValue)):
+            return leftValue == rightValue
+        case let (.string(leftValue), .string(rightValue)):
+            return leftValue == rightValue
+        case let (.uint(leftValue), .uint(rightValue)):
+            return leftValue == rightValue
         default:
             return false
         }

--- a/Sources/UtilityBeltUITesting/Models/UserDefaultsObject.swift
+++ b/Sources/UtilityBeltUITesting/Models/UserDefaultsObject.swift
@@ -1,0 +1,101 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+public struct UserDefaultsObject: Codable {
+    // MARK: Properties
+    
+    /// The key used to represent the `value` in `UserDefaults`.
+    public let key: String
+    
+    /// The value to store in `UserDefaults` under the `key`.
+    public let value: Value
+    
+    // MARK: Initialization
+    
+    public init(key: String, value: Value) {
+        self.key = key
+        self.value = value
+    }
+}
+
+// MARK: - Equatable
+
+extension UserDefaultsObject: Equatable {}
+
+// MARK: - UserDefaultsObject.Value
+
+public extension UserDefaultsObject {
+    enum Value: Codable {
+        // MARK: CodingKeys
+        
+        enum CodingKeys: String, CodingKey {
+            case date
+            case int
+            case object
+        }
+        
+        // MARK: Cases
+        
+        case date(Date)
+        case int(Int)
+        indirect case object(UserDefaultsObject)
+        case `nil`
+        
+        // MARK: Decoding
+        
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            
+            switch container.allKeys.first {
+            case .date:
+                let value = try container.decode(Date.self, forKey: .date)
+                self = .date(value)
+            case .int:
+                let value = try container.decode(Int.self, forKey: .int)
+                self = .int(value)
+            case .object:
+                let value = try container.decode(UserDefaultsObject.self, forKey: .object)
+                self = .object(value)
+            case nil:
+                self = .nil
+            }
+        }
+        
+        // MARK: Encoding
+        
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            
+            switch self {
+            case let .date(value):
+                try container.encode(value, forKey: .date)
+            case let .int(value):
+                try container.encode(value, forKey: .int)
+            case let .object(value):
+                try container.encode(value, forKey: .object)
+            case .nil:
+                break
+            }
+        }
+    }
+}
+
+// MARK: - UserDefaultsObject.Value + Equatable
+
+extension UserDefaultsObject.Value: Equatable {
+    public static func == (lhs: UserDefaultsObject.Value, rhs: UserDefaultsObject.Value) -> Bool {
+        switch (lhs, rhs) {
+        case let (.date(leftDate), .date(rightDate)):
+            return leftDate == rightDate
+        case let (.int(leftInt), .int(rightInt)):
+            return leftInt == rightInt
+        case let (.object(leftObject), .object(rightObject)):
+            return leftObject == rightObject
+        case (.nil, .nil):
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Tests/UtilityBeltUITestingTests/Tests/UserDefaultsConfigurationTests.swift
+++ b/Tests/UtilityBeltUITestingTests/Tests/UserDefaultsConfigurationTests.swift
@@ -47,24 +47,34 @@ final class UserDefaultsConfigurationTests: XCTestCase {
         XCTAssertEqual(firstObject.value, .int(1))
     }
     
-    func testInjectIntoUserDefaults() {
+    func testInjectIntoUserDefaults() throws {
         let configuration = UserDefaultsConfiguration()
 
-        // Store objects to be saved in the standard UserDefaults.
-        let intKey = "TestInt"
-        let intValue = 2
-        configuration.storeUserDefaultsObject(UserDefaultsObject(key: intKey, value: .int(intValue)))
+        // Store objects to be saved in the both the standard and custom UserDefaults.
+        let dateKey = "TestDate"
+        let dateValue = Date()
+        let dateObject = UserDefaultsObject(key: dateKey, value: .date(dateValue))
+        configuration.storeUserDefaultsObject(dateObject)
         
-        // Verify the current UserDefaults.standard doesn't contain the keys we'll inject.
-        XCTAssertNil(UserDefaults.standard.value(forKey: intKey))
+        let suiteName = "TestSuite"
+        configuration.storeUserDefaultsObject(dateObject, inSuite: suiteName)
+                
+        // Verify the UserDefaults do not contain the keys we'll inject.
+        XCTAssertNil(UserDefaults.standard.value(forKey: dateKey))
+        let customDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        XCTAssertNil(customDefaults.value(forKey: dateKey))
         
         // Inject the stored objects.
         configuration.injectIntoUserDefaults()
         
-        // Verify they were saved in UserDefaults.standard.
-        XCTAssertEqual(UserDefaults.standard.value(forKey: intKey) as? Int, intValue)
+        // Verify the object was saved in UserDefaults.standard.
+        XCTAssertEqual(UserDefaults.standard.value(forKey: dateKey) as? Date, dateValue)
         
+        // Verify the object was saved in the custom suite.
+        XCTAssertEqual(customDefaults.value(forKey: dateKey) as? Date, dateValue)
+
         // Clean up the UserDefaults.
-        UserDefaults.standard.removeObject(forKey: intKey)
+        UserDefaults.standard.removeObject(forKey: dateKey)
+        customDefaults.removeObject(forKey: dateKey)
     }
 }

--- a/Tests/UtilityBeltUITestingTests/Tests/UserDefaultsConfigurationTests.swift
+++ b/Tests/UtilityBeltUITestingTests/Tests/UserDefaultsConfigurationTests.swift
@@ -1,0 +1,49 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+import Foundation
+@testable import UtilityBeltUITesting
+import XCTest
+
+final class UserDefaultsConfigurationTests: XCTestCase {
+    // MARK: Tests
+    
+    func testStoringStandardDefaultsObject() throws {
+        let configuration = UserDefaultsConfiguration()
+
+        // Verify there are no user default objects upon initialization.
+        XCTAssertTrue(configuration.standard.isEmpty)
+        XCTAssertTrue(configuration.customSuites.isEmpty)
+
+        // Verify calling storeUserDefaultsObject(_:) updates the standard array.
+        configuration.storeUserDefaultsObject(UserDefaultsObject(key: "Testing", value: .int(1)))
+        XCTAssertEqual(configuration.standard.count, 1)
+        XCTAssertTrue(configuration.customSuites.isEmpty)
+        
+        let firstObject = try XCTUnwrap(configuration.standard.first)
+        XCTAssertEqual(firstObject.key, "Testing")
+        XCTAssertEqual(firstObject.value, .int(1))
+    }
+
+    func testStoringCustomSuiteObject() throws {
+        let configuration = UserDefaultsConfiguration()
+
+        // Verify there are no user default objects upon initialization.
+        XCTAssertTrue(configuration.standard.isEmpty)
+        XCTAssertTrue(configuration.customSuites.isEmpty)
+
+        // Verify calling storeUserDefaultsObject(_: inSuite:) updates the custom suites dictionary.
+        configuration.storeUserDefaultsObject(UserDefaultsObject(key: "Testing", value: .int(1)), inSuite: "TestSuite")
+        XCTAssertEqual(configuration.customSuites.keys.count, 1)
+        XCTAssertTrue(configuration.standard.isEmpty)
+                
+        let firstSuiteKey = try XCTUnwrap(configuration.customSuites.keys.first)
+        XCTAssertEqual(firstSuiteKey, "TestSuite")
+        
+        let firstSuiteObjects = try XCTUnwrap(configuration.customSuites[firstSuiteKey])
+        XCTAssertEqual(firstSuiteObjects.count, 1)
+        
+        let firstObject = try XCTUnwrap(firstSuiteObjects.first)
+        XCTAssertEqual(firstObject.key, "Testing")
+        XCTAssertEqual(firstObject.value, .int(1))
+    }
+}

--- a/Tests/UtilityBeltUITestingTests/Tests/UserDefaultsConfigurationTests.swift
+++ b/Tests/UtilityBeltUITestingTests/Tests/UserDefaultsConfigurationTests.swift
@@ -46,4 +46,25 @@ final class UserDefaultsConfigurationTests: XCTestCase {
         XCTAssertEqual(firstObject.key, "Testing")
         XCTAssertEqual(firstObject.value, .int(1))
     }
+    
+    func testInjectIntoUserDefaults() {
+        let configuration = UserDefaultsConfiguration()
+
+        // Store objects to be saved in the standard UserDefaults.
+        let intKey = "TestInt"
+        let intValue = 2
+        configuration.storeUserDefaultsObject(UserDefaultsObject(key: intKey, value: .int(intValue)))
+        
+        // Verify the current UserDefaults.standard doesn't contain the keys we'll inject.
+        XCTAssertNil(UserDefaults.standard.value(forKey: intKey))
+        
+        // Inject the stored objects.
+        configuration.injectIntoUserDefaults()
+        
+        // Verify they were saved in UserDefaults.standard.
+        XCTAssertEqual(UserDefaults.standard.value(forKey: intKey) as? Int, intValue)
+        
+        // Clean up the UserDefaults.
+        UserDefaults.standard.removeObject(forKey: intKey)
+    }
 }

--- a/Tests/UtilityBeltUITestingTests/Tests/UserDefaultsObjectTests.swift
+++ b/Tests/UtilityBeltUITestingTests/Tests/UserDefaultsObjectTests.swift
@@ -1,0 +1,61 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+import Foundation
+@testable import UtilityBeltUITesting
+import XCTest
+
+final class UserDefaultsObjectTests: XCTestCase {
+    func testEncodingAndDecodingValues() throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        
+        // Bool
+        let boolValue = UserDefaultsObject.Value.bool(true)
+        let encodedBoolValue = try encoder.encode(boolValue)
+        let decodedBoolValue = try decoder.decode(UserDefaultsObject.Value.self, from: encodedBoolValue)
+        XCTAssertEqual(decodedBoolValue, boolValue)
+        
+        // Data
+        let stringData = try XCTUnwrap("testing".data(using: .utf8))
+        let dataValue = UserDefaultsObject.Value.data(stringData)
+        let encodedDataValue = try encoder.encode(dataValue)
+        let decodedDataValue = try decoder.decode(UserDefaultsObject.Value.self, from: encodedDataValue)
+        XCTAssertEqual(decodedDataValue, dataValue)
+        
+        // Date
+        let dateValue = UserDefaultsObject.Value.date(Date())
+        let encodedDateValue = try encoder.encode(dateValue)
+        let decodedDateValue = try decoder.decode(UserDefaultsObject.Value.self, from: encodedDateValue)
+        XCTAssertEqual(decodedDateValue, dateValue)
+        
+        // Double
+        let doubleValue = UserDefaultsObject.Value.double(1.1)
+        let encodedDoubleValue = try encoder.encode(doubleValue)
+        let decodedDoubleValue = try decoder.decode(UserDefaultsObject.Value.self, from: encodedDoubleValue)
+        XCTAssertEqual(decodedDoubleValue, doubleValue)
+        
+        // Float
+        let floatValue = UserDefaultsObject.Value.float(1.1)
+        let encodedFloatValue = try encoder.encode(floatValue)
+        let decodedFloatValue = try decoder.decode(UserDefaultsObject.Value.self, from: encodedFloatValue)
+        XCTAssertEqual(decodedFloatValue, floatValue)
+        
+        // Int
+        let intValue = UserDefaultsObject.Value.int(1)
+        let encodedIntValue = try encoder.encode(intValue)
+        let decodedIntValue = try decoder.decode(UserDefaultsObject.Value.self, from: encodedIntValue)
+        XCTAssertEqual(decodedIntValue, intValue)
+        
+        // String
+        let stringValue = UserDefaultsObject.Value.string("Testing")
+        let encodedStringValue = try encoder.encode(stringValue)
+        let decodedStringValue = try decoder.decode(UserDefaultsObject.Value.self, from: encodedStringValue)
+        XCTAssertEqual(decodedStringValue, stringValue)
+        
+        // UInt
+        let uintValue = UserDefaultsObject.Value.uint(1)
+        let encodedUIntValue = try encoder.encode(uintValue)
+        let decodedUIntValue = try decoder.decode(UserDefaultsObject.Value.self, from: encodedUIntValue)
+        XCTAssertEqual(decodedUIntValue, uintValue)
+    }
+}


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-2697

**Description**
Added a configuration object to store UserDefaults data to be injected in the main app when UI testing.

The configuration object has two properties, `var standard: [UserDefaultsObject]` and `customSuites: [String: [UserDefaultsObject]]`. The former contains objects to be injected into `UserDefaults.standard` and the later contains array of objects to be injected into UserDefaults with custom suite names, represented by the dictionary's key.


The `UserDefaultsObject`s have two properties, `key` and `value`. The former is the string key used in UserDefaults. The latter is a `Codable` type for easy transfer to the main app, with support for basic types which can be stored in UserDefaults.