### PR TITLE
IOS-2705: Feature/Launch argument enumeration

### DIFF
--- a/Sources/UtilityBeltUITesting/Enumerations/LaunchArgument.swift
+++ b/Sources/UtilityBeltUITesting/Enumerations/LaunchArgument.swift
@@ -1,0 +1,8 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+/// An enumeration of launch arguments used when launching an XCUIApplication.
+public enum LaunchArgument: String {
+    case xcuiTestCase
+}

--- a/Sources/UtilityBeltUITesting/Enumerations/LaunchArgument.swift
+++ b/Sources/UtilityBeltUITesting/Enumerations/LaunchArgument.swift
@@ -3,6 +3,6 @@
 import Foundation
 
 /// An enumeration of launch arguments used when launching an XCUIApplication.
-public enum LaunchArgument: String {
-    case xcuiTestCase
+public enum LaunchArgument {
+    case custom(value: String)
 }

--- a/Sources/UtilityBeltUITesting/Enumerations/LaunchArgument.swift
+++ b/Sources/UtilityBeltUITesting/Enumerations/LaunchArgument.swift
@@ -4,22 +4,7 @@ import Foundation
 
 /// An enumeration of launch arguments used when launching an XCUIApplication.
 public enum LaunchArgument {
-    /// An argument and associated value.
-    case argument(key: String, value: String)
-    /// A custom string value argument.
-    case custom(key: String)
-    /// A user default argument and associated value.
-    case userDefault(key: String, value: String)
-    
-    /// Returns the properly formatted key for the launch argument.
-    public var formattedKey: String {
-        switch self {
-        case let .argument(key, _):
-            return "--" + key
-        case let .custom(key):
-            return key
-        case let .userDefault(key, _):
-            return "-" + key
-        }
-    }
+    /// An custom argument.
+    case custom(value: String)
+    // TODO: https://spothero.atlassian.net/browse/IOS-2719 Set up proper command line arguments and user defaults.
 }

--- a/Sources/UtilityBeltUITesting/Enumerations/LaunchArgument.swift
+++ b/Sources/UtilityBeltUITesting/Enumerations/LaunchArgument.swift
@@ -4,5 +4,19 @@ import Foundation
 
 /// An enumeration of launch arguments used when launching an XCUIApplication.
 public enum LaunchArgument {
-    case custom(value: String)
+    case custom(key: String)
+    case userDefault(key: String, value: String)
+    case argument(key: String, value: String)
+    
+    /// Returns the properly formatted key for the launch argument.
+    public var formattedKey: String {
+        switch self {
+        case let .custom(key):
+            return key
+        case let .userDefault(key, _):
+            return "-" + key
+        case let .argument(key, _):
+            return "--" + key
+        }
+    }
 }

--- a/Sources/UtilityBeltUITesting/Enumerations/LaunchArgument.swift
+++ b/Sources/UtilityBeltUITesting/Enumerations/LaunchArgument.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// An enumeration of launch arguments used when launching an XCUIApplication.
 public enum LaunchArgument {
-    /// An custom argument.
+    /// A custom argument.
     case custom(value: String)
     // TODO: https://spothero.atlassian.net/browse/IOS-2719 Set up proper command line arguments and user defaults.
 }

--- a/Sources/UtilityBeltUITesting/Enumerations/LaunchArgument.swift
+++ b/Sources/UtilityBeltUITesting/Enumerations/LaunchArgument.swift
@@ -4,19 +4,22 @@ import Foundation
 
 /// An enumeration of launch arguments used when launching an XCUIApplication.
 public enum LaunchArgument {
-    case custom(key: String)
-    case userDefault(key: String, value: String)
+    /// An argument and associated value.
     case argument(key: String, value: String)
+    /// A custom string value argument.
+    case custom(key: String)
+    /// A user default argument and associated value.
+    case userDefault(key: String, value: String)
     
     /// Returns the properly formatted key for the launch argument.
     public var formattedKey: String {
         switch self {
+        case let .argument(key, _):
+            return "--" + key
         case let .custom(key):
             return key
         case let .userDefault(key, _):
             return "-" + key
-        case let .argument(key, _):
-            return "--" + key
         }
     }
 }

--- a/Sources/UtilityBeltUITesting/Extensions/ProcessInfo+LaunchArguments.swift
+++ b/Sources/UtilityBeltUITesting/Extensions/ProcessInfo+LaunchArguments.swift
@@ -7,6 +7,9 @@ public extension ProcessInfo {
     /// - Parameter argument: The argument in question.
     /// - Returns: Whether or not the arguments for the process contain the specific launch argument.
     static func containsLaunchArgument(_ argument: LaunchArgument) -> Bool {
-        return self.processInfo.arguments.contains(argument.formattedKey)
+        switch argument {
+        case let .custom(value):
+            return self.processInfo.arguments.contains(value)
+        }
     }
 }

--- a/Sources/UtilityBeltUITesting/Extensions/ProcessInfo+LaunchArguments.swift
+++ b/Sources/UtilityBeltUITesting/Extensions/ProcessInfo+LaunchArguments.swift
@@ -7,6 +7,9 @@ public extension ProcessInfo {
     /// - Parameter argument: The argument in question.
     /// - Returns: Whether or not the arguments for the process contain the specific launch argument.
     static func containsLaunchArgument(_ argument: LaunchArgument) -> Bool {
-        return self.processInfo.arguments.contains(argument.rawValue)
+        switch argument {
+        case let .custom(value):
+            return self.processInfo.arguments.contains(value)
+        }
     }
 }

--- a/Sources/UtilityBeltUITesting/Extensions/ProcessInfo+LaunchArguments.swift
+++ b/Sources/UtilityBeltUITesting/Extensions/ProcessInfo+LaunchArguments.swift
@@ -7,9 +7,6 @@ public extension ProcessInfo {
     /// - Parameter argument: The argument in question.
     /// - Returns: Whether or not the arguments for the process contain the specific launch argument.
     static func containsLaunchArgument(_ argument: LaunchArgument) -> Bool {
-        switch argument {
-        case let .custom(value):
-            return self.processInfo.arguments.contains(value)
-        }
+        return self.processInfo.arguments.contains(argument.formattedKey)
     }
 }

--- a/Sources/UtilityBeltUITesting/Extensions/ProcessInfo+LaunchArguments.swift
+++ b/Sources/UtilityBeltUITesting/Extensions/ProcessInfo+LaunchArguments.swift
@@ -1,0 +1,12 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+public extension ProcessInfo {
+    /// Determines whether or not the arguments for the process contain the specific launch argument.
+    /// - Parameter argument: The argument in question.
+    /// - Returns: Whether or not the arguments for the process contain the specific launch argument.
+    static func containsLaunchArgument(_ argument: LaunchArgument) -> Bool {
+        return self.processInfo.arguments.contains(argument.rawValue)
+    }
+}

--- a/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
+++ b/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
@@ -13,8 +13,8 @@
                 switch argument {
                 case .custom:
                     self.launchArguments += [argument.formattedKey]
-                case let .userDefault(_, value),
-                     let .argument(_, value):
+                case let .argument(_, value),
+                     let .userDefault(_, value):
                     self.launchArguments += [argument.formattedKey, value]
                 }
             }

--- a/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
+++ b/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
@@ -10,7 +10,7 @@
         /// - Parameter objects: An array of launch argument objects that will be adding into the launch arguments.
         func updateLaunchArguments(_ arguments: [LaunchArgument]) {
             arguments.forEach { argument in
-                // Remove the argument in the case that it already there.
+                // Remove the argument in the case that it already exists.
                 self.removeLaunchArgument(argument)
                 self.launchArguments += [argument.rawValue]
             }

--- a/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
+++ b/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
@@ -15,7 +15,7 @@
                     self.launchArguments.append(argument.formattedKey)
                 case let .argument(_, value),
                      let .userDefault(_, value):
-                    self.launchArguments += [argument.formattedKey, value]
+                    self.launchArguments.append(contentsOf: [argument.formattedKey, value])
                 }
             }
         }

--- a/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
+++ b/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
@@ -12,7 +12,7 @@
             arguments.forEach { argument in
                 switch argument {
                 case .custom:
-                    self.launchArguments += [argument.formattedKey]
+                    self.launchArguments.append(argument.formattedKey)
                 case let .argument(_, value),
                      let .userDefault(_, value):
                     self.launchArguments += [argument.formattedKey, value]

--- a/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
+++ b/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
@@ -12,7 +12,7 @@
             arguments.forEach { argument in
                 switch argument {
                 case let .custom(value):
-                    self.launchArguments += [value]
+                    self.launchArguments.append(value)
                 }
             }
         }

--- a/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
+++ b/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
@@ -1,0 +1,28 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+#if canImport(XCTest)
+
+    import UtilityBeltUITesting
+    import XCTest
+
+    public extension XCUIApplication {
+        /// Convenience method for merging new launch arguments into the launch arguments array.
+        /// - Parameter objects: An array of launch argument objects that will be adding into the launch arguments.
+        func updateLaunchArguments(_ arguments: [LaunchArgument]) {
+            arguments.forEach { argument in
+                // Remove the argument in the case that it already there.
+                self.removeLaunchArgument(argument)
+                self.launchArguments += [argument.rawValue]
+            }
+        }
+        
+        /// Remove an argument from the launch arguments, if it exists.
+        /// - Parameter argument: The argument to remove.
+        func removeLaunchArgument(_ argument: LaunchArgument) {
+            self.launchArguments.removeAll(where: { existingValue in
+                existingValue == argument.rawValue
+            })
+        }
+    }
+
+#endif

--- a/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
+++ b/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
@@ -8,8 +8,13 @@
     public extension XCUIApplication {
         /// Convenience method for merging new launch arguments into the launch arguments array.
         /// - Parameter objects: An array of launch argument objects that will be adding into the launch arguments.
-        func updateLaunchArguments(_ arguments: [LaunchArgument]) {
-            self.launchArguments += arguments.map(\.rawValue).filter { !self.launchArguments.contains($0) }
+        func appendLaunchArguments(_ arguments: [LaunchArgument]) {
+            arguments.forEach { argument in
+                switch argument {
+                case let .custom(value):
+                    self.launchArguments += [value]
+                }
+            }
         }
     }
 

--- a/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
+++ b/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
@@ -9,19 +9,7 @@
         /// Convenience method for merging new launch arguments into the launch arguments array.
         /// - Parameter objects: An array of launch argument objects that will be adding into the launch arguments.
         func updateLaunchArguments(_ arguments: [LaunchArgument]) {
-            arguments.forEach { argument in
-                // Remove the argument in the case that it already exists.
-                self.removeLaunchArgument(argument)
-                self.launchArguments += [argument.rawValue]
-            }
-        }
-        
-        /// Remove an argument from the launch arguments, if it exists.
-        /// - Parameter argument: The argument to remove.
-        func removeLaunchArgument(_ argument: LaunchArgument) {
-            self.launchArguments.removeAll(where: { existingValue in
-                existingValue == argument.rawValue
-            })
+            self.launchArguments += arguments.map(\.rawValue).filter { !self.launchArguments.contains($0) }
         }
     }
 

--- a/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
+++ b/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
@@ -11,11 +11,8 @@
         func appendLaunchArguments(_ arguments: [LaunchArgument]) {
             arguments.forEach { argument in
                 switch argument {
-                case .custom:
-                    self.launchArguments.append(argument.formattedKey)
-                case let .argument(_, value),
-                     let .userDefault(_, value):
-                    self.launchArguments.append(contentsOf: [argument.formattedKey, value])
+                case let .custom(value):
+                    self.launchArguments += [value]
                 }
             }
         }

--- a/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
+++ b/Sources/UtilityBeltUITesting_XCTestSupport/Extensions/XCUIApplication+LaunchArguments.swift
@@ -11,8 +11,11 @@
         func appendLaunchArguments(_ arguments: [LaunchArgument]) {
             arguments.forEach { argument in
                 switch argument {
-                case let .custom(value):
-                    self.launchArguments += [value]
+                case .custom:
+                    self.launchArguments += [argument.formattedKey]
+                case let .userDefault(_, value),
+                     let .argument(_, value):
+                    self.launchArguments += [argument.formattedKey, value]
                 }
             }
         }


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-2705

**Description**
Creates a `LaunchArgument` enumeration.
Creates helper extensions for setting values from a test target and checking `LaunchArgument` values when running a test.
