### PR TITLE
IOS-2791: Bugfix/Handle NSNumbers properly

### DIFF
--- a/Sources/UtilityBeltNetworking/Extensions/NSNumber+Boolean.swift
+++ b/Sources/UtilityBeltNetworking/Extensions/NSNumber+Boolean.swift
@@ -1,0 +1,9 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+extension NSNumber {
+    var isBoolean: Bool {
+        return CFGetTypeID(self as CFTypeRef) == CFBooleanGetTypeID()
+    }
+}

--- a/Sources/UtilityBeltNetworking/Extensions/NSNumber+Boolean.swift
+++ b/Sources/UtilityBeltNetworking/Extensions/NSNumber+Boolean.swift
@@ -3,6 +3,8 @@
 import Foundation
 
 extension NSNumber {
+    /// Returns wether or not the underlying value is a boolean value.
+    /// Used to distinguish the difference between a zero and false value or a one and true value.
     var isBoolean: Bool {
         return CFGetTypeID(self as CFTypeRef) == CFBooleanGetTypeID()
     }

--- a/Sources/UtilityBeltNetworking/Extensions/URLComponents+SetQueryItems.swift
+++ b/Sources/UtilityBeltNetworking/Extensions/URLComponents+SetQueryItems.swift
@@ -38,7 +38,7 @@ extension URLComponents {
             }
         case let value:
             // If the value is a boolean, display it as "true"/"false"
-            if let nsNumber = value as? NSNumber, CFGetTypeID(nsNumber as CFTypeRef) == CFBooleanGetTypeID() {
+            if let nsNumber = value as? NSNumber, nsNumber.isBoolean {
                 return [URLQueryItem(name: parameter.key, value: String(describing: nsNumber.boolValue))]
             } else {
                 return [URLQueryItem(name: parameter.key, value: String(describing: value))]

--- a/Sources/UtilityBeltNetworking/Extensions/URLComponents+SetQueryItems.swift
+++ b/Sources/UtilityBeltNetworking/Extensions/URLComponents+SetQueryItems.swift
@@ -1,4 +1,4 @@
-// Copyright © 2020 SpotHero, Inc. All rights reserved.
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
 
 import Foundation
 
@@ -36,11 +36,13 @@ extension URLComponents {
                 // Example: array[][][] (no indexes!)
                 self.evaluatedQueryItems(for: (key: "\(parameter.key)[]", value: $0))
             }
-        case let bool as Bool:
-            // TODO: Allow encoding of bools as numbers
-            return [URLQueryItem(name: parameter.key, value: "\(bool)")]
         case let value:
-            return [URLQueryItem(name: parameter.key, value: String(describing: value))]
+            // If the value is a boolean, display it as "true"/"false"
+            if let nsNumber = value as? NSNumber, CFGetTypeID(nsNumber as CFTypeRef) == CFBooleanGetTypeID() {
+                return [URLQueryItem(name: parameter.key, value: String(describing: nsNumber.boolValue))]
+            } else {
+                return [URLQueryItem(name: parameter.key, value: String(describing: value))]
+            }
         }
     }
 }

--- a/Tests/UtilityBeltNetworkingTests/Tests/NSNumberExtensionTests.swift
+++ b/Tests/UtilityBeltNetworkingTests/Tests/NSNumberExtensionTests.swift
@@ -1,0 +1,18 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+@testable import UtilityBeltNetworking
+import XCTest
+
+class NSNumberExtensionTests: XCTestCase {
+    func testIsBoolean() {
+        // WHEN: I have a boolean NSNumber
+        let booleanNSNumber = NSNumber(false)
+        // THEN: The `isBoolean` property will return true.
+        XCTAssertTrue(booleanNSNumber.isBoolean)
+        
+        // WHEN: I have a boolean NSNumber
+        let integerNSNumber = NSNumber(1)
+        // THEN: The `isBoolean` property will return false.
+        XCTAssertFalse(integerNSNumber.isBoolean)
+    }
+}

--- a/Tests/UtilityBeltNetworkingTests/Tests/NSNumberExtensionTests.swift
+++ b/Tests/UtilityBeltNetworkingTests/Tests/NSNumberExtensionTests.swift
@@ -10,7 +10,7 @@ class NSNumberExtensionTests: XCTestCase {
         // THEN: The `isBoolean` property will return true.
         XCTAssertTrue(booleanNSNumber.isBoolean)
         
-        // WHEN: I have a boolean NSNumber
+        // WHEN: I have a non-boolean NSNumber
         let integerNSNumber = NSNumber(1)
         // THEN: The `isBoolean` property will return false.
         XCTAssertFalse(integerNSNumber.isBoolean)

--- a/Tests/UtilityBeltNetworkingTests/Tests/ParameterEncodingTests.swift
+++ b/Tests/UtilityBeltNetworkingTests/Tests/ParameterEncodingTests.swift
@@ -128,10 +128,10 @@ final class ParameterEncodingTests: XCTestCase {
         let queryItems = try XCTUnwrap(URLComponents(url: requestURL, resolvingAgainstBaseURL: true)?.queryItems)
         
         // THEN: The NSNumber values are properly serialized.
-        XCTAssertTrue(queryItems.filter { $0.name == "boolNSNumber" }.first?.value == "true")
-        XCTAssertTrue(queryItems.filter { $0.name == "intNSNumber" }.first?.value == "1")
-        XCTAssertTrue(queryItems.filter { $0.name == "bool" }.first?.value == "false")
-        XCTAssertTrue(queryItems.filter { $0.name == "int" }.first?.value == "3")
+        XCTAssertTrue(queryItems.first { $0.name == "boolNSNumber" }?.value == "true")
+        XCTAssertTrue(queryItems.first { $0.name == "intNSNumber" }?.value == "1")
+        XCTAssertTrue(queryItems.first { $0.name == "bool" }?.value == "false")
+        XCTAssertTrue(queryItems.first { $0.name == "int" }?.value == "3")
     }
     
     /// Helper to create a request.

--- a/Tests/UtilityBeltNetworkingTests/Tests/ParameterEncodingTests.swift
+++ b/Tests/UtilityBeltNetworkingTests/Tests/ParameterEncodingTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2020 SpotHero, Inc. All rights reserved.
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
 
 @testable import UtilityBeltNetworking
 import XCTest
@@ -31,6 +31,12 @@ final class ParameterEncodingTests: XCTestCase {
             "bob",
             "carol",
         ],
+    ]
+    private var nsNumberParameters: [String: Any] = [
+        "boolNSNumber": NSNumber(booleanLiteral: true),
+        "intNSNumber": NSNumber(integerLiteral: 1),
+        "bool": false,
+        "int": 3,
     ]
     
     func testPostDefaultRequest() {
@@ -108,6 +114,24 @@ final class ParameterEncodingTests: XCTestCase {
         
         // THEN: The body contains the serialized data.
         self.dataIsInBody(request: request)
+    }
+    
+    func testNSNumberURLEncoding() throws {
+        let method = HTTPMethod.get
+        let url = try XCTUnwrap("spothero.com".asURL())
+        var request = URLRequest(url: url)
+        request.httpMethod = method.rawValue
+        
+        // GIVEN: I create a request that contains parameter values that are NSNumbers.
+        request.setParameters(self.nsNumberParameters, method: method, encoding: nil)
+        let requestURL = try XCTUnwrap(request.url)
+        let queryItems = try XCTUnwrap(URLComponents(url: requestURL, resolvingAgainstBaseURL: true)?.queryItems)
+        
+        // THEN: The NSNumber values are properly serialized.
+        XCTAssertTrue(queryItems.filter { $0.name == "boolNSNumber" }.first?.value == "true")
+        XCTAssertTrue(queryItems.filter { $0.name == "intNSNumber" }.first?.value == "1")
+        XCTAssertTrue(queryItems.filter { $0.name == "bool" }.first?.value == "false")
+        XCTAssertTrue(queryItems.filter { $0.name == "int" }.first?.value == "3")
     }
     
     /// Helper to create a request.

--- a/Tests/UtilityBeltNetworkingTests/Tests/ParameterEncodingTests.swift
+++ b/Tests/UtilityBeltNetworkingTests/Tests/ParameterEncodingTests.swift
@@ -33,8 +33,8 @@ final class ParameterEncodingTests: XCTestCase {
         ],
     ]
     private var nsNumberParameters: [String: Any] = [
-        "boolNSNumber": NSNumber(booleanLiteral: true),
-        "intNSNumber": NSNumber(integerLiteral: 1),
+        "boolNSNumber": NSNumber(true),
+        "intNSNumber": NSNumber(1),
         "bool": false,
         "int": 3,
     ]


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-2791

**Description**
When parameters are encoded using a `JSONSerialization` object, all the numbers become `NSNumber`s.

`NSNumber`s can be converted to `Bool`s, so the switch originally was formatting all number values from the serializer as boolean "true"/"false" strings.

This PR updates the evaluation of query parameters to properly distinguish between Swift booleans and integers, and `NSNumber` booleans and integers.
