### PR TITLE
Updated initializeCoreDataStack to include signature without Bundle

### DIFF
--- a/Sources/UtilityBeltData/CoreData/CoreDataOperator.swift
+++ b/Sources/UtilityBeltData/CoreData/CoreDataOperator.swift
@@ -55,10 +55,20 @@ public class CoreDataOperator {
     ///   - databaseURL: The URL where the database should be persisted. If no URL is given, all data will be stored in memory.
     ///   - bundle: The bundle used to lookup the Core Data model file. Defaults to `.main`.
     public func initializeCoreDataStack(modelName: String, databaseURL: URL?, bundle: Bundle = .main) {
-        guard let url = bundle.url(forResource: modelName, withExtension: "momd") else {
+        guard let modelURL = bundle.url(forResource: modelName, withExtension: "momd") else {
             fatalError("Failed to find \(modelName).momd in bundle \(bundle).")
         }
         
+        self.initializeCoreDataStack(modelURL: modelURL, databaseURL: databaseURL)
+    }
+    
+    /// Initializes a new Core Data stack using the passed in arguments to create a `NSPersistentContainer`.
+    ///
+    /// Ensure `clearCoreData` is called before subsequent calls to this method.
+    /// - Parameters:
+    ///   - modelURL: The URL path to the model (.momd) file to use.
+    ///   - databaseURL: The URL where the database should be persisted. If no URL is given, all data will be stored in memory.
+    public func initializeCoreDataStack(modelURL: URL, databaseURL: URL?) {
         guard let managedObjectModel = NSManagedObjectModel(contentsOf: url) else {
             fatalError("Failed to initialize managed object model with contents of url: \(url)")
         }

--- a/Sources/UtilityBeltData/CoreData/CoreDataOperator.swift
+++ b/Sources/UtilityBeltData/CoreData/CoreDataOperator.swift
@@ -69,8 +69,8 @@ public class CoreDataOperator {
     ///   - modelURL: The URL path to the model (.momd) file to use.
     ///   - databaseURL: The URL where the database should be persisted. If no URL is given, all data will be stored in memory.
     public func initializeCoreDataStack(modelURL: URL, databaseURL: URL?) {
-        guard let managedObjectModel = NSManagedObjectModel(contentsOf: url) else {
-            fatalError("Failed to initialize managed object model with contents of url: \(url)")
+        guard let managedObjectModel = NSManagedObjectModel(contentsOf: modelURL) else {
+            fatalError("Failed to initialize managed object model with contents of url: \(modelURL)")
         }
         
         let container = NSPersistentContainer(name: "CoreData", managedObjectModel: managedObjectModel)

--- a/UtilityBelt.xcworkspace/xcshareddata/xcschemes/UtilityBelt.xcscheme
+++ b/UtilityBelt.xcworkspace/xcshareddata/xcschemes/UtilityBelt.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "UtilityBelt"
-               BuildableName = "UtilityBelt"
-               BlueprintName = "UtilityBelt"
+               BlueprintIdentifier = "Sham"
+               BuildableName = "Sham"
+               BlueprintName = "Sham"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,9 +28,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "Sham"
-               BuildableName = "Sham"
-               BlueprintName = "Sham"
+               BlueprintIdentifier = "Sham_XCTestSupport"
+               BuildableName = "Sham_XCTestSupport"
+               BlueprintName = "Sham_XCTestSupport"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -59,6 +59,34 @@
                BlueprintIdentifier = "UtilityBeltNetworking"
                BuildableName = "UtilityBeltNetworking"
                BlueprintName = "UtilityBeltNetworking"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "UtilityBeltUITesting"
+               BuildableName = "UtilityBeltUITesting"
+               BlueprintName = "UtilityBeltUITesting"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "UtilityBeltUITesting_XCTestSupport"
+               BuildableName = "UtilityBeltUITesting_XCTestSupport"
+               BlueprintName = "UtilityBeltUITesting_XCTestSupport"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -117,6 +145,17 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "UtilityBeltUITestingTests"
+               BuildableName = "UtilityBeltUITestingTests"
+               BlueprintName = "UtilityBeltUITestingTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -139,9 +178,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "UtilityBelt"
-            BuildableName = "UtilityBelt"
-            BlueprintName = "UtilityBelt"
+            BlueprintIdentifier = "Sham"
+            BuildableName = "Sham"
+            BlueprintName = "Sham"
             ReferencedContainer = "container:">
          </BuildableReference>
       </MacroExpansion>


### PR DESCRIPTION
**Description**
SPM doesn't allow referencing a given package's Bundle outside of the package. Within the package, `Bundle.module` references the module's bundle (similar to `Bundle.main` from within an app or framework target). Instead, the pattern intended by SPM is to expose the resources you need via the API of the package itself, which is how `CoreDataHelper.modelURL` works.

This change allows an entrypoint into the method that doesn't handle the Bundle fetching itself without requiring any deprecations, but eventually we may want to move the other method (with `Bundle = .main`) entirely.
