### PR TITLE
IOS-2691: Feature/Remove stub managing functions from the MockService class

### DIFF
--- a/Sources/Sham/Extensions/StubbedDataCollection+URLRequestConvertible.swift
+++ b/Sources/Sham/Extensions/StubbedDataCollection+URLRequestConvertible.swift
@@ -1,0 +1,28 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+import Foundation
+import UtilityBeltNetworking
+
+public extension StubbedDataCollection {
+    /// Returns a stubbed response if there is a stubbed request that matches.
+    /// - Parameter urlRequest: The URL, URLRequest, or URL String to match against stubbed requests.
+    func getResponse(for urlRequest: URLRequestConvertible) -> StubResponse? {
+        let request = StubRequest(urlRequest: urlRequest)
+        return self.getResponse(for: request)
+    }
+    
+    /// Determines whether or not a matching request has been stubbed.
+    /// - Parameter urlRequest: The URL, URLRequest, or URL String to match against stubbed requests.
+    func hasStub(for urlRequest: URLRequestConvertible) -> Bool {
+        let request = StubRequest(urlRequest: urlRequest)
+        return self.hasStub(for: request)
+    }
+    
+    /// Adds a response to the stub response collection.
+    /// - Parameter urlRequest: The URL, URLRequest, or URL String to stub.
+    /// - Parameter response: The response to return upon receiving the given request.
+    func stub(_ urlRequest: URLRequestConvertible, with response: StubResponse) {
+        let request = StubRequest(urlRequest: urlRequest)
+        return self.stub(request, with: response)
+    }
+}

--- a/Sources/Sham/MockService.swift
+++ b/Sources/Sham/MockService.swift
@@ -29,7 +29,7 @@ public class MockService {
     }()
     
     /// A dictionary of stubbed responses keyed by stubbed requests.
-    private var stubbedDataCollection = StubbedDataCollection()
+    public private(set) var stubbedDataCollection = StubbedDataCollection()
     
     /// Whether or not there are any stubbed response.
     public var hasStubs: Bool {
@@ -84,14 +84,6 @@ public class MockService {
     public func canMockData(for urlRequest: URLRequestConvertible) -> Bool {
         let request = StubRequest(urlRequest: urlRequest)
         return self.canMockData(for: request)
-    }
-    
-    /// Adds a response to the stub response collection.
-    /// - Parameter urlRequest: The URL, URLRequest, or URL String to stub.
-    /// - Parameter response: The response to return upon receiving the given request.
-    public func stub(_ urlRequest: URLRequestConvertible, with response: StubResponse) {
-        let request = StubRequest(urlRequest: urlRequest)
-        return self.stubbedDataCollection.stub(request, with: response)
     }
     
     // MARK: Utilities

--- a/Sources/Sham/MockService.swift
+++ b/Sources/Sham/MockService.swift
@@ -29,7 +29,7 @@ public class MockService {
     }()
     
     /// A dictionary of stubbed responses keyed by stubbed requests.
-    public private(set) var stubbedDataCollection = StubbedDataCollection()
+    public var stubbedDataCollection = StubbedDataCollection()
     
     /// Whether or not there are any stubbed response.
     public var hasStubs: Bool {
@@ -62,12 +62,6 @@ public class MockService {
     }
     
     // MARK: Stubbing
-    
-    /// Clears the current stub information and updates to use the information on the passed in collection.
-    /// - Parameter collection: The collection to use.
-    public func updateStubbedData(withCollection collection: StubbedDataCollection) {
-        self.stubbedDataCollection = collection
-    }
     
     /// Determines whether or not the service can attempt to mock a given request.
     /// Returns true if the service is attempting to intercept and mock all requests.

--- a/Sources/Sham/MockService.swift
+++ b/Sources/Sham/MockService.swift
@@ -1,4 +1,4 @@
-// Copyright © 2020 SpotHero, Inc. All rights reserved.
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
 
 import Foundation
 import UtilityBeltNetworking
@@ -72,24 +72,11 @@ public class MockService {
         }
     }
     
-    /// Returns the stubbed response that matches the request.
-    /// Returns nil if there is no matching stubbed request found.
-    /// - Parameter request: The request to match against stubbed requests.
-    public func getResponse(for request: StubRequest) -> StubResponse? {
-        return self.stubbedDataCollection.getResponse(for: request)
-    }
-    
-    /// Determines whether or not a matching request has been stubbed.
-    /// - Parameter request: The request to match against stubbed requests.
-    public func hasStub(for request: StubRequest) -> Bool {
-        return self.getResponse(for: request) != nil
-    }
-    
     /// Determines whether or not the service can attempt to mock a given request.
     /// Returns true if the service is attempting to intercept and mock all requests.
     /// - Parameter request: The request to match against stubbed requests.
     public func canMockData(for request: StubRequest) -> Bool {
-        return self.isMockingAllRequests || self.hasStub(for: request)
+        return self.isMockingAllRequests || self.stubbedDataCollection.hasStub(for: request)
     }
     
     /// Adds a response to the stub response collection for the MockService.
@@ -105,14 +92,14 @@ public class MockService {
     /// - Parameter urlRequest: The URL, URLRequest, or URL String to match against stubbed requests.
     public func getResponse(for urlRequest: URLRequestConvertible) -> StubResponse? {
         let request = StubRequest(urlRequest: urlRequest)
-        return self.getResponse(for: request)
+        return self.stubbedDataCollection.getResponse(for: request)
     }
     
     /// Determines whether or not a matching request has been stubbed.
     /// - Parameter urlRequest: The URL, URLRequest, or URL String to match against stubbed requests.
     public func hasStub(for urlRequest: URLRequestConvertible) -> Bool {
         let request = StubRequest(urlRequest: urlRequest)
-        return self.hasStub(for: request)
+        return self.stubbedDataCollection.hasStub(for: request)
     }
     
     /// Determines whether or not the service can attempt to mock a given request.

--- a/Sources/Sham/MockService.swift
+++ b/Sources/Sham/MockService.swift
@@ -66,10 +66,7 @@ public class MockService {
     /// Clears the current stub information and updates to use the information on the passed in collection.
     /// - Parameter collection: The collection to use.
     public func updateStubbedData(withCollection collection: StubbedDataCollection) {
-        self.clearData()
-        collection.stubbedData.forEach { request, response in
-            self.stub(request, with: response)
-        }
+        self.stubbedDataCollection = collection
     }
     
     /// Determines whether or not the service can attempt to mock a given request.

--- a/Sources/Sham/MockService.swift
+++ b/Sources/Sham/MockService.swift
@@ -29,7 +29,7 @@ public class MockService {
     }()
     
     /// A dictionary of stubbed responses keyed by stubbed requests.
-    private let stubbedDataCollection = StubbedDataCollection()
+    private var stubbedDataCollection = StubbedDataCollection()
     
     /// Whether or not there are any stubbed response.
     public var hasStubs: Bool {
@@ -79,28 +79,7 @@ public class MockService {
         return self.isMockingAllRequests || self.stubbedDataCollection.hasStub(for: request)
     }
     
-    /// Adds a response to the stub response collection for the MockService.
-    /// - Parameter request: The request to stub.
-    /// - Parameter response: The response to return upon receiving the given request.
-    public func stub(_ request: StubRequest, with response: StubResponse) {
-        self.stubbedDataCollection.stub(request, with: response)
-    }
-    
     // MARK: URLRequest Convenience
-    
-    /// Returns a stubbed response if there is a stubbed request that matches.
-    /// - Parameter urlRequest: The URL, URLRequest, or URL String to match against stubbed requests.
-    public func getResponse(for urlRequest: URLRequestConvertible) -> StubResponse? {
-        let request = StubRequest(urlRequest: urlRequest)
-        return self.stubbedDataCollection.getResponse(for: request)
-    }
-    
-    /// Determines whether or not a matching request has been stubbed.
-    /// - Parameter urlRequest: The URL, URLRequest, or URL String to match against stubbed requests.
-    public func hasStub(for urlRequest: URLRequestConvertible) -> Bool {
-        let request = StubRequest(urlRequest: urlRequest)
-        return self.stubbedDataCollection.hasStub(for: request)
-    }
     
     /// Determines whether or not the service can attempt to mock a given request.
     /// Returns true if the service is attempting to intercept and mock all requests.
@@ -115,7 +94,7 @@ public class MockService {
     /// - Parameter response: The response to return upon receiving the given request.
     public func stub(_ urlRequest: URLRequestConvertible, with response: StubResponse) {
         let request = StubRequest(urlRequest: urlRequest)
-        return self.stub(request, with: response)
+        return self.stubbedDataCollection.stub(request, with: response)
     }
     
     // MARK: Utilities

--- a/Sources/Sham/Models/StubbedDataCollection.swift
+++ b/Sources/Sham/Models/StubbedDataCollection.swift
@@ -1,7 +1,6 @@
 // Copyright © 2021 SpotHero, Inc. All rights reserved.
 
 import Foundation
-import UtilityBeltNetworking
 
 /// An object that manages a collection of stubbed data.
 public final class StubbedDataCollection: Codable {
@@ -71,30 +70,6 @@ public final class StubbedDataCollection: Codable {
         
         // Return the response
         return response
-    }
-    
-    // MARK: URLRequest Convenience
-    
-    /// Returns a stubbed response if there is a stubbed request that matches.
-    /// - Parameter urlRequest: The URL, URLRequest, or URL String to match against stubbed requests.
-    public func getResponse(for urlRequest: URLRequestConvertible) -> StubResponse? {
-        let request = StubRequest(urlRequest: urlRequest)
-        return self.getResponse(for: request)
-    }
-    
-    /// Determines whether or not a matching request has been stubbed.
-    /// - Parameter urlRequest: The URL, URLRequest, or URL String to match against stubbed requests.
-    public func hasStub(for urlRequest: URLRequestConvertible) -> Bool {
-        let request = StubRequest(urlRequest: urlRequest)
-        return self.hasStub(for: request)
-    }
-    
-    /// Adds a response to the stub response collection.
-    /// - Parameter urlRequest: The URL, URLRequest, or URL String to stub.
-    /// - Parameter response: The response to return upon receiving the given request.
-    public func stub(_ urlRequest: URLRequestConvertible, with response: StubResponse) {
-        let request = StubRequest(urlRequest: urlRequest)
-        return self.stub(request, with: response)
     }
     
     // MARK: Utilities

--- a/Sources/Sham/Models/StubbedDataCollection.swift
+++ b/Sources/Sham/Models/StubbedDataCollection.swift
@@ -1,4 +1,4 @@
-// Copyright © 2020 SpotHero, Inc. All rights reserved.
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
 
 import Foundation
 
@@ -31,6 +31,12 @@ public final class StubbedDataCollection: Codable {
         }
         
         self.stubbedData[request] = response
+    }
+    
+    /// Determines whether or not a matching request has been stubbed.
+    /// - Parameter request: The request to match against stubbed requests.
+    public func hasStub(for request: StubRequest) -> Bool {
+        return self.getResponse(for: request) != nil
     }
     
     /// Returns the stubbed response that matches the request.

--- a/Sources/Sham/Models/StubbedDataCollection.swift
+++ b/Sources/Sham/Models/StubbedDataCollection.swift
@@ -1,6 +1,7 @@
 // Copyright © 2021 SpotHero, Inc. All rights reserved.
 
 import Foundation
+import UtilityBeltNetworking
 
 /// An object that manages a collection of stubbed data.
 public final class StubbedDataCollection: Codable {
@@ -70,6 +71,30 @@ public final class StubbedDataCollection: Codable {
         
         // Return the response
         return response
+    }
+    
+    // MARK: URLRequest Convenience
+    
+    /// Returns a stubbed response if there is a stubbed request that matches.
+    /// - Parameter urlRequest: The URL, URLRequest, or URL String to match against stubbed requests.
+    public func getResponse(for urlRequest: URLRequestConvertible) -> StubResponse? {
+        let request = StubRequest(urlRequest: urlRequest)
+        return self.getResponse(for: request)
+    }
+    
+    /// Determines whether or not a matching request has been stubbed.
+    /// - Parameter urlRequest: The URL, URLRequest, or URL String to match against stubbed requests.
+    public func hasStub(for urlRequest: URLRequestConvertible) -> Bool {
+        let request = StubRequest(urlRequest: urlRequest)
+        return self.hasStub(for: request)
+    }
+    
+    /// Adds a response to the stub response collection.
+    /// - Parameter urlRequest: The URL, URLRequest, or URL String to stub.
+    /// - Parameter response: The response to return upon receiving the given request.
+    public func stub(_ urlRequest: URLRequestConvertible, with response: StubResponse) {
+        let request = StubRequest(urlRequest: urlRequest)
+        return self.stub(request, with: response)
     }
     
     // MARK: Utilities

--- a/Sources/Sham/Protocols/MockURLProtocol.swift
+++ b/Sources/Sham/Protocols/MockURLProtocol.swift
@@ -1,4 +1,4 @@
-// Copyright © 2020 SpotHero, Inc. All rights reserved.
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
 
 import Foundation
 import UtilityBeltNetworking
@@ -32,7 +32,7 @@ public class MockURLProtocol: URLProtocol {
             return
         }
         
-        let stubResponse = MockService.shared.getResponse(for: self.request)
+        let stubResponse = MockService.shared.stubbedDataCollection.getResponse(for: self.request)
         
         let httpResponse = HTTPURLResponse(url: url,
                                            statusCode: stubResponse?.statusCode.rawValue ?? HTTPStatusCode.badRequest.rawValue,

--- a/Sources/Sham_XCTestSupport/Extensions/XCTestCase+Stub.swift
+++ b/Sources/Sham_XCTestSupport/Extensions/XCTestCase+Stub.swift
@@ -1,4 +1,4 @@
-// Copyright © 2020 SpotHero, Inc. All rights reserved.
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
 
 #if canImport(XCTest)
 
@@ -11,14 +11,14 @@
         /// - Parameter stubRequest: The request to stub.
         /// - Parameter response: The response to return.
         func stub(_ stubRequest: StubRequest, with response: StubResponse) {
-            MockService.shared.stub(stubRequest, with: response)
+            MockService.shared.stubbedDataCollection.stub(stubRequest, with: response)
         }
     
         /// Convenience method for stubbing new requests within an XCTestCase.
         /// - Parameter urlRequest: The request to stub.
         /// - Parameter response: The response to return.
         func stub(_ urlRequest: URLRequestConvertible, with response: StubResponse) {
-            MockService.shared.stub(urlRequest, with: response)
+            MockService.shared.stubbedDataCollection.stub(urlRequest, with: response)
         }
     }
 

--- a/Sources/UtilityBeltUITesting/Extensions/MockService+LaunchEnvironment.swift
+++ b/Sources/UtilityBeltUITesting/Extensions/MockService+LaunchEnvironment.swift
@@ -10,6 +10,6 @@ public extension MockService {
         guard let stubbedDataCollection = ProcessInfo.fetchFromLaunchEnvironment(withType: StubbedDataCollection.self) else {
             return
         }
-        MockService.shared.updateStubbedData(withCollection: stubbedDataCollection)
+        MockService.shared.stubbedDataCollection = stubbedDataCollection
     }
 }

--- a/Tests/ShamTests/Tests/MockServiceTests.swift
+++ b/Tests/ShamTests/Tests/MockServiceTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2020 SpotHero, Inc. All rights reserved.
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
 
 @testable import Sham
 import Sham_XCTestSupport
@@ -77,7 +77,7 @@ final class MockServiceTests: XCTestCase {
     func testStubbingGetFailsPostRequests() {
         self.stub(.get(self.fullURL), with: .encodable(self.mockData))
         
-        let hasData = MockService.shared.hasStub(for: .post(self.fullURL))
+        let hasData = MockService.shared.stubbedDataCollection.hasStub(for: .post(self.fullURL))
         
         XCTAssertTrue(MockService.shared.hasStubs)
         XCTAssertFalse(hasData)
@@ -87,7 +87,7 @@ final class MockServiceTests: XCTestCase {
         // Attempting to stub a scheme-only URL should not load any data into the MockService
         self.stub(self.schemeOnlyURL, with: .encodable(self.mockData))
         
-        let hasData = MockService.shared.hasStub(for: self.schemeOnlyURL)
+        let hasData = MockService.shared.stubbedDataCollection.hasStub(for: self.schemeOnlyURL)
         
         XCTAssertFalse(MockService.shared.hasStubs)
         XCTAssertFalse(hasData)
@@ -97,7 +97,7 @@ final class MockServiceTests: XCTestCase {
         // Attempting to stub a query-only URL should not load any data into the MockService
         self.stub(self.queryOnlyURL, with: .encodable(self.mockData))
         
-        let hasData = MockService.shared.hasStub(for: self.queryOnlyURL)
+        let hasData = MockService.shared.stubbedDataCollection.hasStub(for: self.queryOnlyURL)
         
         XCTAssertFalse(MockService.shared.hasStubs)
         XCTAssertFalse(hasData)


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-2691

**Description**
Removes the thin wrapper functions in `MockService` that manipulate the stubbed data collection object and allows the direct manipulation of the `MockService.shared.stubbedDataCollection` property.
