### PR TITLE
IOS-2916: Feature/Control XCUI Layer Speed

### DIFF
--- a/Sources/UtilityBeltUITesting/Models/AnimationConfiguration.swift
+++ b/Sources/UtilityBeltUITesting/Models/AnimationConfiguration.swift
@@ -11,6 +11,7 @@ public struct AnimationConfiguration: LaunchEnvironmentCodable {
     public var animationsEnabled: Bool
     
     /// The value with which to set the application's key window layer speed.
+    ///
     /// See Apple's [documentation](https://developer.apple.com/documentation/quartzcore/camediatiming/1427647-speed) for more information.
     public var layerAnimationSpeed: Float
     

--- a/Sources/UtilityBeltUITesting/Models/AnimationConfiguration.swift
+++ b/Sources/UtilityBeltUITesting/Models/AnimationConfiguration.swift
@@ -10,7 +10,12 @@ public struct AnimationConfiguration: LaunchEnvironmentCodable {
     /// Whether or not animations are enabled.
     public var animationsEnabled: Bool
     
-    public init(animationsEnabled: Bool) {
+    /// The value with which to set the application's `keyWindow.layer.speed` property.
+    /// See Apple's [documentation](https://developer.apple.com/documentation/quartzcore/camediatiming/1427647-speed) for more information.
+    public var layerAnimationSpeed: Float
+    
+    public init(animationsEnabled: Bool, layerAnimationSpeed: Float = 1.0) {
         self.animationsEnabled = animationsEnabled
+        self.layerAnimationSpeed = layerAnimationSpeed
     }
 }

--- a/Sources/UtilityBeltUITesting/Models/AnimationConfiguration.swift
+++ b/Sources/UtilityBeltUITesting/Models/AnimationConfiguration.swift
@@ -10,7 +10,7 @@ public struct AnimationConfiguration: LaunchEnvironmentCodable {
     /// Whether or not animations are enabled.
     public var animationsEnabled: Bool
     
-    /// The value with which to set the application's `keyWindow.layer.speed` property.
+    /// The value with which to set the application's key window layer speed.
     /// See Apple's [documentation](https://developer.apple.com/documentation/quartzcore/camediatiming/1427647-speed) for more information.
     public var layerAnimationSpeed: Float
     


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-2916

**Description**
Added a new property to `AnimationConfiguration` that allows passing information to the app target about the desired speed for the key window's layer.