### PR TITLE
IOS-3047: Feature/Enable Matching URL requests based on query parameters

### DIFF
--- a/Sources/Sham/Models/StubbedDataCollection.swift
+++ b/Sources/Sham/Models/StubbedDataCollection.swift
@@ -94,18 +94,6 @@ public final class StubbedDataCollection: Codable {
             return highestPriorityStubs.first?.value
         }
         
-        // If there are no parameters on the request find a response stub
-        // without parameters, if it exists.
-        if request.url?.query?.isEmpty != false {
-            let highestPriorityStub = highestPriorityStubs.first(where: {
-                $0.key.url?.query?.isEmpty == true
-            })?.value
-            
-            if let highestPriorityStub = highestPriorityStub {
-                return highestPriorityStub
-            }
-        }
-        
         // With the highest priority stubs, now compare based on parameter values.
         return highestPriorityStubs.max {
             $0.key.matchingParameterCount(for: request) < $1.key.matchingParameterCount(for: request)

--- a/Sources/Sham/Models/StubbedDataCollection.swift
+++ b/Sources/Sham/Models/StubbedDataCollection.swift
@@ -89,11 +89,6 @@ public final class StubbedDataCollection: Codable {
             $0.key.priorityScore(for: request) == maxPriorityScore
         }
         
-        // If there only one, it's the best match.
-        guard highestPriorityStubs.count > 1 else {
-            return highestPriorityStubs.first?.value
-        }
-        
         // With the highest priority stubs, now compare based on parameter values.
         return highestPriorityStubs.max {
             $0.key.matchingParameterCount(for: request) < $1.key.matchingParameterCount(for: request)

--- a/Tests/ShamTests/Tests/MockServiceTests.swift
+++ b/Tests/ShamTests/Tests/MockServiceTests.swift
@@ -17,6 +17,8 @@ final class MockServiceTests: XCTestCase {
     let querylessURL = "https://foo.com/foo"
     let secondaryMockData = ["bar", "foo"]
     
+    let manyQueryParamsURL = "https://foo.com/foo?foo=bar&foo2=bar2&foo3=bar3"
+    
     override func setUp() {
         super.setUp()
         
@@ -123,11 +125,12 @@ final class MockServiceTests: XCTestCase {
     }
     
     func testReturnsStubWithMostEqualParametersUsingBestMatch() throws {
-        // GIVEN: I stub a queryless URL.
-        self.stub(self.querylessURL, with: .encodable(self.mockData))
+        // GIVEN: I stub a URL with only one query.
+        self.stub(self.fullURL, with: .encodable(self.mockData))
         
-        // THEN: The values should return correctly even if the URL that is requested has parameters.
-        self.request(url: self.fullURL, data: self.mockData)
+        // THEN: The values should return correctly even if the URL that is requested has multiple
+        // query parameters.
+        self.request(url: self.manyQueryParamsURL, data: self.mockData)
     }
     
     private func request<T>(url: URLConvertible,

--- a/Tests/ShamTests/Tests/MockServiceTests.swift
+++ b/Tests/ShamTests/Tests/MockServiceTests.swift
@@ -14,6 +14,9 @@ final class MockServiceTests: XCTestCase {
     
     let mockData = ["foo", "bar"]
     
+    let querylessURL = "https://foo.com/foo"
+    let secondaryMockData = ["bar", "foo"]
+    
     override func setUp() {
         super.setUp()
         
@@ -101,6 +104,30 @@ final class MockServiceTests: XCTestCase {
         
         XCTAssertFalse(MockService.shared.hasStubs)
         XCTAssertFalse(hasData)
+    }
+    
+    func testReturnsStubWithMostEqualParameters() throws {
+        // GIVEN: Two URLs have the same base base URL and path.
+        let fullURL = try XCTUnwrap(URL(string: self.fullURL))
+        let queryLessURL = try XCTUnwrap(URL(string: self.querylessURL))
+        XCTAssertEqual(fullURL.baseURL, queryLessURL.baseURL)
+        XCTAssertEqual(fullURL.path, queryLessURL.path)
+        
+        // GIVEN: I stub similar URLs with different query params.
+        self.stub(self.fullURL, with: .encodable(self.mockData))
+        self.stub(self.querylessURL, with: .encodable(self.secondaryMockData))
+        
+        // THEN: The values should return correctly.
+        self.request(url: self.fullURL, data: self.mockData)
+        self.request(url: self.querylessURL, data: self.secondaryMockData)
+    }
+    
+    func testReturnsStubWithMostEqualParametersUsingBestMatch() throws {
+        // GIVEN: I stub a queryless URL.
+        self.stub(self.querylessURL, with: .encodable(self.mockData))
+        
+        // THEN: The values should return correctly even if the URL that is requested has parameters.
+        self.request(url: self.fullURL, data: self.mockData)
     }
     
     private func request<T>(url: URLConvertible,

--- a/Tests/ShamTests/Tests/MockServiceTests.swift
+++ b/Tests/ShamTests/Tests/MockServiceTests.swift
@@ -134,6 +134,21 @@ final class MockServiceTests: XCTestCase {
         self.request(url: self.manyQueryParamsURL, data: self.secondaryMockData)
     }
     
+    func testReturnsStubWithQueryParametersEvenIfTheRequestDoesNotHaveQueryParameters() throws {
+        // GIVEN: Two stub URLs have the same base base URL and path.
+        let fullURL = try XCTUnwrap(URL(string: self.fullURL))
+        let queryLessURL = try XCTUnwrap(URL(string: self.querylessURL))
+        XCTAssertEqual(fullURL.baseURL, queryLessURL.baseURL)
+        XCTAssertEqual(fullURL.path, queryLessURL.path)
+        
+        // GIVEN: I stub a URL with query params.
+        self.stub(self.fullURL, with: .encodable(self.mockData))
+        
+        // THEN: The value should return correctly, even if the request does not have query
+        // params.
+        self.request(url: self.querylessURL, data: self.mockData)
+    }
+    
     private func request<T>(url: URLConvertible,
                             data: T,
                             shouldFail: Bool = false,

--- a/Tests/ShamTests/Tests/MockServiceTests.swift
+++ b/Tests/ShamTests/Tests/MockServiceTests.swift
@@ -7,14 +7,13 @@ import XCTest
 
 final class MockServiceTests: XCTestCase {
     let fullURL = "https://foo.com/foo?foo=bar"
+    let querylessURL = "https://foo.com/foo"
     let schemeOnlyURL = "https://"
     let hostOnlyURL = "//foo.com"
     let pathOnlyURL = "/foo"
     let queryOnlyURL = "?foo=bar"
     
     let mockData = ["foo", "bar"]
-    
-    let querylessURL = "https://foo.com/foo"
     let secondaryMockData = ["bar", "foo"]
     
     let manyQueryParamsURL = "https://foo.com/foo?foo=bar&foo2=bar2&foo3=bar3"
@@ -109,28 +108,30 @@ final class MockServiceTests: XCTestCase {
     }
     
     func testReturnsStubWithMostEqualParameters() throws {
-        // GIVEN: Two URLs have the same base base URL and path.
-        let fullURL = try XCTUnwrap(URL(string: self.fullURL))
-        let queryLessURL = try XCTUnwrap(URL(string: self.querylessURL))
-        XCTAssertEqual(fullURL.baseURL, queryLessURL.baseURL)
-        XCTAssertEqual(fullURL.path, queryLessURL.path)
-        
-        // GIVEN: I stub similar URLs with different query params.
-        self.stub(self.fullURL, with: .encodable(self.mockData))
-        self.stub(self.querylessURL, with: .encodable(self.secondaryMockData))
-        
-        // THEN: The values should return correctly.
-        self.request(url: self.fullURL, data: self.mockData)
-        self.request(url: self.querylessURL, data: self.secondaryMockData)
-    }
-    
-    func testReturnsStubWithMostEqualParametersUsingBestMatch() throws {
         // GIVEN: I stub a URL with only one query.
         self.stub(self.fullURL, with: .encodable(self.mockData))
         
         // THEN: The values should return correctly even if the URL that is requested has multiple
         // query parameters.
         self.request(url: self.manyQueryParamsURL, data: self.mockData)
+    }
+    
+    func testReturnsStubWithMostEqualParametersBasedOnBestMatch() throws {
+        // GIVEN: Two stub URLs have the same base base URL and path.
+        let fullURL = try XCTUnwrap(URL(string: self.fullURL))
+        let queryLessURL = try XCTUnwrap(URL(string: self.querylessURL))
+        XCTAssertEqual(fullURL.baseURL, queryLessURL.baseURL)
+        XCTAssertEqual(fullURL.path, queryLessURL.path)
+        
+        // GIVEN: I stub similar URLs with different query params.
+        self.stub(self.querylessURL, with: .encodable(self.mockData))
+        self.stub(self.fullURL, with: .encodable(self.secondaryMockData))
+        
+        // THEN: The values should return correctly.
+        self.request(url: self.querylessURL, data: self.mockData)
+        self.request(url: self.fullURL, data: self.secondaryMockData)
+        
+        self.request(url: self.manyQueryParamsURL, data: self.secondaryMockData)
     }
     
     private func request<T>(url: URLConvertible,

--- a/Tests/ShamTests/Tests/StubRequestTests.swift
+++ b/Tests/ShamTests/Tests/StubRequestTests.swift
@@ -25,4 +25,14 @@ final class StubRequestTests: XCTestCase {
         let request = StubRequest(url: self.baseURLString)
         XCTAssertEqual(request.description, "ALL: \(self.baseURLString)")
     }
+    
+    func testAccuratelyCountsMatchingQueryParameters() {
+        let queryParametersURL = "\(self.baseURLString)?zebra=thing&aardvark=other_thing&giraffe=thing_3"
+        let request1: StubRequest = .get(queryParametersURL)
+        
+        let similarURL = "\(self.baseURLString)?aardvark=other_thing&zebra=thing"
+        let request2: StubRequest = .get(similarURL)
+        
+        XCTAssertEqual(2, request1.matchingParameterCount(for: request2))
+    }
 }


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-3047

**Description**
Allows the mock service to return stubbed data based on the most amount of query parameters that are equal. Instead of having to have all the query parameters correct, you can now specify an arbitrary amount of query parameters when stubbing and get the best match when requesting.
