### PR TITLE
Fix failing Git Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
   lint:
     name: Lint
     runs-on: macos-latest
+    permissions:
+      pull-requests: write
     env:
       DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
**Issue Link**
N/A

**Description**
Fixes the failing Git Actions by allowing Danger to write to PRs.
