### PR TITLE
IOS-1967: Handle mime type check in decodable requests

### DIFF
--- a/Sources/Sham/Models/StubResponse.swift
+++ b/Sources/Sham/Models/StubResponse.swift
@@ -19,6 +19,9 @@ public struct StubResponse {
     /// A dictionary of headers to be returned in the response.
     public var headers: [String: String]
     
+    /// The mime type of the response
+    public var mimeType: MimeType?
+    
     // MARK: - Methods
     
     // MARK: Initializers
@@ -28,11 +31,17 @@ public struct StubResponse {
     /// - Parameter error: The error to be returned in the response.
     /// - Parameter statusCode: The status code of the response.
     /// - Parameter headers: A dictionary of headers to be returned in the response.
-    public init(data: Data? = nil, error: Error? = nil, statusCode: HTTPStatusCode = .ok, headers: [String: String] = [:]) {
+    /// - Parameter mimeType: The mime type of the response
+    public init(data: Data? = nil,
+                error: Error? = nil,
+                statusCode: HTTPStatusCode = .ok,
+                headers: [String: String] = [:],
+                mimeType: MimeType? = nil) {
         self.data = data
         self.error = error
         self.statusCode = statusCode
         self.headers = headers
+        self.mimeType = mimeType
     }
 }
 
@@ -44,24 +53,27 @@ extension StubResponse: Codable {
     // TODO: Figure out how to encode the error object.
     private enum CodingKeys: String, CodingKey {
         case data
-        case statusCode
         case headers
+        case mimeType
+        case statusCode
     }
     
     /// Enables a StubResponse object to be encoded. This has been customized to handle not encoding the error property.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(self.data, forKey: .data)
-        try container.encode(self.statusCode, forKey: .statusCode)
         try container.encode(self.headers, forKey: .headers)
+        try container.encode(self.mimeType, forKey: .mimeType)
+        try container.encode(self.statusCode, forKey: .statusCode)
     }
     
     /// Enables a StubResponse object to be decoded. This has been customized to handle not decoding the error property.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.data = try container.decodeIfPresent(Data.self, forKey: .data)
-        self.statusCode = try container.decode(HTTPStatusCode.self, forKey: .statusCode)
         self.headers = try container.decode([String: String].self, forKey: .headers)
+        self.mimeType = try container.decode(MimeType.self, forKey: .headers)
+        self.statusCode = try container.decode(HTTPStatusCode.self, forKey: .statusCode)
     }
 }
 
@@ -72,23 +84,29 @@ public extension StubResponse {
     /// - Parameter data: The raw data to be returned in the response.
     /// - Parameter statusCode: The status code of the response.
     /// - Parameter headers: A dictionary of headers to be returned in the response.
-    static func data(_ data: Data, statusCode: HTTPStatusCode = .ok, headers: [String: String] = [:]) -> StubResponse {
-        return self.init(data: data, statusCode: statusCode, headers: headers)
+    /// - Parameter mimeType: The mime type of the response
+    static func data(_ data: Data,
+                     statusCode: HTTPStatusCode = .ok,
+                     headers: [String: String] = [:],
+                     mimeType: MimeType? = nil) -> StubResponse {
+        return self.init(data: data, statusCode: statusCode, headers: headers, mimeType: mimeType)
     }
     
     /// Initializes a StubResponse by encoding an Encodable Swift class into JSON data.
     /// - Parameter encodable: The Encodable Swift class to encode.
     /// - Parameter statusCode: The status code of the response.
     /// - Parameter headers: A dictionary of headers to be returned in the response.
+    /// - Parameter mimeType: The mime type of the response
     static func encodable<T>(_ encodable: T,
                              statusCode: HTTPStatusCode = .ok,
-                             headers: [String: String] = [:]) -> StubResponse where T: Encodable {
+                             headers: [String: String] = [:],
+                             mimeType: MimeType? = .json) -> StubResponse where T: Encodable {
         do {
             let data = try JSONEncoder().encode(encodable)
-            return self.init(data: data, statusCode: statusCode, headers: headers)
+            return self.init(data: data, statusCode: statusCode, headers: headers, mimeType: mimeType)
         } catch {
             assertionFailure("Unable to encode type \(String(describing: T.self)) for stubbing.")
-            return self.init(data: nil, statusCode: statusCode, headers: headers)
+            return self.init(data: nil, statusCode: statusCode, headers: headers, mimeType: mimeType)
         }
     }
     
@@ -96,15 +114,22 @@ public extension StubResponse {
     /// - Parameter error: The error to be returned in the response.
     /// - Parameter statusCode: The status code of the response. Defaults to `Internal Server Error` (`500`).
     /// - Parameter headers: A dictionary of headers to be returned in the response.
-    static func error(_ error: Error, statusCode: HTTPStatusCode = .internalServerError, headers: [String: String] = [:]) -> StubResponse {
-        return self.init(error: error, statusCode: statusCode, headers: headers)
+    /// - Parameter mimeType: The mime type of the response
+    static func error(_ error: Error,
+                      statusCode: HTTPStatusCode = .internalServerError,
+                      headers: [String: String] = [:],
+                      mimeType: MimeType? = nil) -> StubResponse {
+        return self.init(error: error, statusCode: statusCode, headers: headers, mimeType: mimeType)
     }
     
     /// Initializes a StubResponse without any data.
     /// - Parameter statusCode: The status code of the response.
     /// - Parameter headers: A dictionary of headers to be returned in the response.
-    static func http(statusCode: HTTPStatusCode = .ok, headers: [String: String] = [:]) -> StubResponse {
-        return self.init(statusCode: statusCode, headers: headers)
+    /// - Parameter mimeType: The mime type of the response
+    static func http(statusCode: HTTPStatusCode = .ok,
+                     headers: [String: String] = [:],
+                     mimeType: MimeType? = nil) -> StubResponse {
+        return self.init(statusCode: statusCode, headers: headers, mimeType: mimeType)
     }
     
     /// Initializes a StubResponse by getting data from the contents of a file relative to the source file path.
@@ -115,6 +140,7 @@ public extension StubResponse {
     static func relativeFile(_ relativeFilePath: String,
                              statusCode: HTTPStatusCode = .ok,
                              headers: [String: String] = [:],
+                             mimeType: MimeType? = nil,
                              sourceFile: StaticString = #file) -> StubResponse {
         let sourceFileURL = URL(fileURLWithPath: "\(sourceFile)", isDirectory: false)
         let sourceFileDirectory = sourceFileURL.deletingLastPathComponent()
@@ -123,11 +149,11 @@ public extension StubResponse {
         // Verify that file exists at the relative path
         guard FileManager.default.fileExists(atPath: filePath) else {
             assertionFailure("Unable to find file: '\(filePath)'.")
-            return self.init(data: nil, statusCode: statusCode, headers: headers)
+            return self.init(data: nil, statusCode: statusCode, headers: headers, mimeType: mimeType)
         }
         
         let data = FileManager.default.contents(atPath: filePath)
-        return self.init(data: data, statusCode: statusCode, headers: headers)
+        return self.init(data: data, statusCode: statusCode, headers: headers, mimeType: mimeType)
     }
     
     /// Initializes a StubResponse by getting data from the contents of a resource.
@@ -142,7 +168,8 @@ public extension StubResponse {
                          subdirectory: String? = nil,
                          bundle: Bundle? = nil,
                          statusCode: HTTPStatusCode = .ok,
-                         headers: [String: String] = [:]) -> StubResponse {
+                         headers: [String: String] = [:],
+                         mimeType: MimeType? = nil) -> StubResponse {
         let bundle = bundle ?? MockService.shared.defaultBundle
         
         guard let resourceURL = bundle.url(forResource: path, withExtension: fileExtension, subdirectory: subdirectory) else {
@@ -152,10 +179,10 @@ public extension StubResponse {
         
         do {
             let data = try Data(contentsOf: resourceURL)
-            return self.init(data: data, statusCode: statusCode, headers: headers)
+            return self.init(data: data, statusCode: statusCode, headers: headers, mimeType: mimeType)
         } catch {
             assertionFailure("Unable to get data from resource: '\(path)'.")
-            return self.init(data: nil, statusCode: statusCode, headers: headers)
+            return self.init(data: nil, statusCode: statusCode, headers: headers, mimeType: mimeType)
         }
     }
 }

--- a/Sources/Sham/Protocols/MockURLProtocol.swift
+++ b/Sources/Sham/Protocols/MockURLProtocol.swift
@@ -34,10 +34,18 @@ public class MockURLProtocol: URLProtocol {
         
         let stubResponse = MockService.shared.stubbedDataCollection.getResponse(for: self.request)
         
+        var headerFields = stubResponse?.headers ?? [:]
+        let contentTypeKey = HTTPHeader.contentType.rawValue
+        
+        // If there is a mime type on the stub response, and the headers don't already contain one, add it to the header dictionary.
+        if let mimeType = stubResponse?.mimeType, !headerFields.keys.contains(contentTypeKey) {
+            headerFields[contentTypeKey] = mimeType.rawValue
+        }
+        
         let httpResponse = HTTPURLResponse(url: url,
                                            statusCode: stubResponse?.statusCode.rawValue ?? HTTPStatusCode.badRequest.rawValue,
                                            httpVersion: nil,
-                                           headerFields: stubResponse?.headers ?? [:])
+                                           headerFields: headerFields)
         
         guard let response = httpResponse else {
             self.client?.urlProtocol(self, didFailWithError: MockURLProtocol.Error.noResponse)

--- a/Sources/UtilityBeltNetworking/Enums/UBNetworkError.swift
+++ b/Sources/UtilityBeltNetworking/Enums/UBNetworkError.swift
@@ -4,6 +4,7 @@ import Foundation
 
 public enum UBNetworkError: Error {
     case invalidContentType(String)
+    case invalidStatusCode(HTTPStatusCode)
     case invalidURLString(String)
     case invalidURLResponse
     case unableToDecode(String, DecodingError?)
@@ -15,6 +16,8 @@ extension UBNetworkError: LocalizedError {
         switch self {
         case let .invalidContentType(contentType):
             return "Invalid content type '\(contentType)'."
+        case let .invalidStatusCode(statusCode):
+            return "Invalid status code '\(statusCode.rawValue)'."
         case let .invalidURLString(urlString):
             return "Invalid URL string '\(urlString)'."
         case .invalidURLResponse:

--- a/Sources/UtilityBeltNetworking/HTTPClient+Combine.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient+Combine.swift
@@ -52,7 +52,9 @@
                     self.log("[Response] \(response)")
                     
                     if let httpResponse = response as? HTTPURLResponse {
-                        try self.validate(response: httpResponse, with: validators)
+                        for validator in validators {
+                            try validator.validate(response: httpResponse)
+                        }
                     }
                 
                     // Attempt to lob the data as pretty printed JSON, otherwise just encode to utf8

--- a/Sources/UtilityBeltNetworking/HTTPClient+Combine.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient+Combine.swift
@@ -52,7 +52,7 @@
                     self.log("[Response] \(response)")
                     
                     if let httpResponse = response as? HTTPURLResponse {
-                        try self.validateResponse(response: httpResponse, with: validators)
+                        try self.validate(response: httpResponse, with: validators)
                     }
                 
                     // Attempt to lob the data as pretty printed JSON, otherwise just encode to utf8

--- a/Sources/UtilityBeltNetworking/HTTPClient+Combine.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient+Combine.swift
@@ -103,7 +103,7 @@
         /// - Parameter parameters: The parameters to be converted into a String-keyed dictionary to send in the query string or HTTP body.
         /// - Parameter headers: The HTTP headers to send with the request.
         /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
-        /// - Parameter validators: An array of validators that will be applied to the response.
+        /// - Parameter validators: An array of validators that will be applied to the response. Defaults to ensuring a JSON mime type on the response.
         /// - Parameter dispatchQueue: The dispatch queue on which the response will be published. Defaults to `.main`.
         /// - Parameter decoder: The `JSONDecoder` to use when decoding the response data.
         /// - Returns: A publisher that wraps a data task for the URL.
@@ -112,14 +112,9 @@
                                             parameters: ParameterDictionaryConvertible? = nil,
                                             headers: HTTPHeaderDictionaryConvertible? = nil,
                                             encoding: ParameterEncoding? = nil,
-                                            validators: [ResponseValidator] = [],
+                                            validators: [ResponseValidator] = [.ensureMimeType(.json)],
                                             dispatchQueue: DispatchQueue = .main,
                                             decoder: JSONDecoder = JSONDecoder()) -> AnyPublisher<T, Error> {
-            // Given that we expect to decode JSON from the response, add
-            // an additional validator that checks the appropriate mime type.
-            var validators = validators
-            validators.append(.ensureMimeType(.json))
-            
             return self.requestPublisher(url,
                                          method: method,
                                          parameters: parameters,
@@ -145,7 +140,7 @@
         /// - Parameter parameters: The `Encodable` object to be converted into a String-keyed dictionary to send in the query string or HTTP body.
         /// - Parameter headers: The HTTP headers to send with the request.
         /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
-        /// - Parameter validators: An array of validators that will be applied to the response.
+        /// - Parameter validators: An array of validators that will be applied to the response. Defaults to ensuring a JSON mime type on the response.
         /// - Parameter dispatchQueue: The dispatch queue on which the response will be published. Defaults to `.main`.
         /// - Parameter decoder: The `JSONDecoder` to use when decoding the response data.
         /// - Returns: A publisher that wraps a data task for the URL.
@@ -155,7 +150,7 @@
                                             parameters: Encodable,
                                             headers: HTTPHeaderDictionaryConvertible? = nil,
                                             encoding: ParameterEncoding? = nil,
-                                            validators: [ResponseValidator] = [],
+                                            validators: [ResponseValidator] = [.ensureMimeType(.json)],
                                             dispatchQueue: DispatchQueue = .main,
                                             decoder: JSONDecoder = JSONDecoder()) -> AnyPublisher<T, Error> {
             return self.requestPublisher(url,

--- a/Sources/UtilityBeltNetworking/HTTPClient+Combine.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient+Combine.swift
@@ -103,7 +103,7 @@
         /// - Parameter parameters: The parameters to be converted into a String-keyed dictionary to send in the query string or HTTP body.
         /// - Parameter headers: The HTTP headers to send with the request.
         /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
-        /// - Parameter validators: An array of validators that will be applied to the response. Defaults to ensuring a JSON mime type on the response.
+        /// - Parameter validators: An array of validators that will be applied to the response. Defaults to ensuring a JSON mime type.
         /// - Parameter dispatchQueue: The dispatch queue on which the response will be published. Defaults to `.main`.
         /// - Parameter decoder: The `JSONDecoder` to use when decoding the response data.
         /// - Returns: A publisher that wraps a data task for the URL.
@@ -140,7 +140,7 @@
         /// - Parameter parameters: The `Encodable` object to be converted into a String-keyed dictionary to send in the query string or HTTP body.
         /// - Parameter headers: The HTTP headers to send with the request.
         /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
-        /// - Parameter validators: An array of validators that will be applied to the response. Defaults to ensuring a JSON mime type on the response.
+        /// - Parameter validators: An array of validators that will be applied to the response. Defaults to ensuring a JSON mime type.
         /// - Parameter dispatchQueue: The dispatch queue on which the response will be published. Defaults to `.main`.
         /// - Parameter decoder: The `JSONDecoder` to use when decoding the response data.
         /// - Returns: A publisher that wraps a data task for the URL.

--- a/Sources/UtilityBeltNetworking/HTTPClient.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient.swift
@@ -30,11 +30,6 @@ public class HTTPClient {
     /// set to be more restrictive. https://stackoverflow.com/a/54806389
     public var timeoutInterval: TimeInterval?
     
-    /// Validators that will be applied to all responses.
-    private let defaultValidators: [ResponseValidator] = [
-        .validateStatusCode,
-    ]
-    
     // MARK: - Methods
     
     // MARK: Initializers
@@ -102,7 +97,9 @@ public class HTTPClient {
             let result: Result<Data, Error> = {
                 if let response = httpResponse {
                     do {
-                        try self.validate(response: response, with: validators)
+                        for validator in validators {
+                            try validator.validate(response: response)
+                        }
                     } catch {
                         return .failure(error)
                     }
@@ -327,17 +324,6 @@ public class HTTPClient {
         }
         
         print("[UtilityBeltNetworking] \(message)")
-    }
-    
-    /// Validates a response against `defaultValidators` and passed in validators.
-    /// - Parameters:
-    ///   - response: The response to perform the validation on.
-    ///   - validators: Additional validators on top of the default validators that should be applied to the response.
-    /// - Throws: Throws any validation errors, indicating failed validation.
-    func validate(response: HTTPURLResponse, with validators: [ResponseValidator]) throws {
-        try (self.defaultValidators + validators).forEach { validator in
-            try validator.validate(response: response)
-        }
     }
 }
 

--- a/Sources/UtilityBeltNetworking/HTTPClient.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient.swift
@@ -209,7 +209,7 @@ public class HTTPClient {
                     }
                 case let .success(data):
                     // If the mime type for the response isn't JSON, we can't decode it
-                    guard dataResponse.response?.mimeType == "application/json" else {
+                    guard dataResponse.response?.mimeType == MimeType.json.rawValue else {
                         return .failure(UBNetworkError.invalidContentType(dataResponse.response?.mimeType ?? "unknown"))
                     }
                     

--- a/Sources/UtilityBeltNetworking/HTTPClient.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient.swift
@@ -190,7 +190,7 @@ public class HTTPClient {
     /// - Parameter parameters: The parameters to be converted into a String-keyed dictionary to send in the query string or HTTP body.
     /// - Parameter headers: The HTTP headers to send with the request.
     /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
-    /// - Parameter validators: An array of validators that will be applied to the response.
+    /// - Parameter validators: An array of validators that will be applied to the response. Defaults to ensuring a JSON mime type on the response.
     /// - Parameter dispatchQueue: The dispatch queue that the completion will be called on. Defaults to `.main`.
     /// - Parameter decoder: The `JSONDecoder` to use when decoding the response data.
     /// - Parameter completion: The completion block to call when the request is completed.
@@ -201,15 +201,10 @@ public class HTTPClient {
                                       parameters: ParameterDictionaryConvertible? = nil,
                                       headers: HTTPHeaderDictionaryConvertible? = nil,
                                       encoding: ParameterEncoding? = nil,
-                                      validators: [ResponseValidator] = [],
+                                      validators: [ResponseValidator] = [.ensureMimeType(.json)],
                                       dispatchQueue: DispatchQueue = .main,
                                       decoder: JSONDecoder = JSONDecoder(),
                                       completion: DecodableTaskCompletion<T>? = nil) -> URLSessionTask? {
-        // Given that we expect to decode JSON from the response, add
-        // an additional validator that checks the appropriate mime type.
-        var validators = validators
-        validators.append(.ensureMimeType(.json))
-        
         return self.request(
             url,
             method: method,
@@ -260,7 +255,7 @@ public class HTTPClient {
     /// - Parameter parameters: The `Encodable` object to be converted into a String-keyed dictionary to send in the query string or HTTP body.
     /// - Parameter headers: The HTTP headers to send with the request.
     /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
-    /// - Parameter validators: An array of validators that will be applied to the response.
+    /// - Parameter validators: An array of validators that will be applied to the response. Defaults to ensuring a JSON mime type on the response.
     /// - Parameter dispatchQueue: The dispatch queue that the completion will be called on. Defaults to `.main`.
     /// - Parameter decoder: The `JSONDecoder` to use when decoding the response data.
     /// - Parameter completion: The completion block to call when the request is completed.
@@ -272,7 +267,7 @@ public class HTTPClient {
                                       parameters: Encodable,
                                       headers: HTTPHeaderDictionaryConvertible? = nil,
                                       encoding: ParameterEncoding? = nil,
-                                      validators: [ResponseValidator] = [],
+                                      validators: [ResponseValidator] = [.ensureMimeType(.json)],
                                       dispatchQueue: DispatchQueue = .main,
                                       decoder: JSONDecoder = JSONDecoder(),
                                       completion: DecodableTaskCompletion<T>? = nil) -> URLSessionTask? {

--- a/Sources/UtilityBeltNetworking/HTTPClient.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient.swift
@@ -53,6 +53,7 @@ public class HTTPClient {
     /// - Parameter parameters: The parameters to be converted into a String-keyed dictionary to send in the query string or HTTP body.
     /// - Parameter headers: The HTTP headers to send with the request.
     /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
+    /// - Parameter validators: An array of validators that will be applied to the response.
     /// - Parameter dispatchQueue: The dispatch queue that the completion will be called on. Defaults to `.main`.
     /// - Parameter completion: The completion block to call when the request is completed.
     /// - Returns: The `URLSessionTask` for the request.
@@ -160,6 +161,7 @@ public class HTTPClient {
     /// - Parameter parameters: The `Encodable` object to be converted into a String-keyed dictionary to send in the query string or HTTP body.
     /// - Parameter headers: The HTTP headers to send with the request.
     /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
+    /// - Parameter validators: An array of validators that will be applied to the response.
     /// - Parameter dispatchQueue: The dispatch queue that the completion will be called on. Defaults to `.main`.
     /// - Parameter completion: The completion block to call when the request is completed.
     /// - Returns: The `URLSessionTask` for the request.
@@ -170,6 +172,7 @@ public class HTTPClient {
                         parameters: Encodable,
                         headers: HTTPHeaderDictionaryConvertible? = nil,
                         encoding: ParameterEncoding? = nil,
+                        validators: [ResponseValidator] = [],
                         dispatchQueue: DispatchQueue = .main,
                         completion: DataTaskCompletion? = nil) -> URLSessionTask? {
         self.request(url,
@@ -177,6 +180,7 @@ public class HTTPClient {
                      parameters: try? parameters.asDictionary(),
                      headers: headers,
                      encoding: encoding,
+                     validators: validators,
                      dispatchQueue: dispatchQueue,
                      completion: completion)
     }
@@ -189,6 +193,7 @@ public class HTTPClient {
     /// - Parameter parameters: The parameters to be converted into a String-keyed dictionary to send in the query string or HTTP body.
     /// - Parameter headers: The HTTP headers to send with the request.
     /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
+    /// - Parameter validators: An array of validators that will be applied to the response.
     /// - Parameter dispatchQueue: The dispatch queue that the completion will be called on. Defaults to `.main`.
     /// - Parameter decoder: The `JSONDecoder` to use when decoding the response data.
     /// - Parameter completion: The completion block to call when the request is completed.
@@ -199,16 +204,22 @@ public class HTTPClient {
                                       parameters: ParameterDictionaryConvertible? = nil,
                                       headers: HTTPHeaderDictionaryConvertible? = nil,
                                       encoding: ParameterEncoding? = nil,
+                                      validators: [ResponseValidator] = [],
                                       dispatchQueue: DispatchQueue = .main,
                                       decoder: JSONDecoder = JSONDecoder(),
                                       completion: DecodableTaskCompletion<T>? = nil) -> URLSessionTask? {
+        // Given that we expect to decode JSON from the response, add
+        // an additional validator that checks the appropriate mime type.
+        var validators = validators
+        validators.append(.ensureMimeType(.json))
+        
         return self.request(
             url,
             method: method,
             parameters: parameters,
             headers: headers,
             encoding: encoding,
-            validators: [.ensureMimeType(.json)],
+            validators: validators,
             dispatchQueue: dispatchQueue
         ) { dataResponse in
             // Create a result object for improved handling of the response
@@ -252,6 +263,7 @@ public class HTTPClient {
     /// - Parameter parameters: The `Encodable` object to be converted into a String-keyed dictionary to send in the query string or HTTP body.
     /// - Parameter headers: The HTTP headers to send with the request.
     /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
+    /// - Parameter validators: An array of validators that will be applied to the response.
     /// - Parameter dispatchQueue: The dispatch queue that the completion will be called on. Defaults to `.main`.
     /// - Parameter decoder: The `JSONDecoder` to use when decoding the response data.
     /// - Parameter completion: The completion block to call when the request is completed.
@@ -263,6 +275,7 @@ public class HTTPClient {
                                       parameters: Encodable,
                                       headers: HTTPHeaderDictionaryConvertible? = nil,
                                       encoding: ParameterEncoding? = nil,
+                                      validators: [ResponseValidator] = [],
                                       dispatchQueue: DispatchQueue = .main,
                                       decoder: JSONDecoder = JSONDecoder(),
                                       completion: DecodableTaskCompletion<T>? = nil) -> URLSessionTask? {
@@ -271,6 +284,7 @@ public class HTTPClient {
                      parameters: try? parameters.asDictionary(),
                      headers: headers,
                      encoding: encoding,
+                     validators: validators,
                      dispatchQueue: dispatchQueue,
                      decoder: decoder,
                      completion: completion)

--- a/Sources/UtilityBeltNetworking/HTTPClient.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient.swift
@@ -208,11 +208,10 @@ public class HTTPClient {
                         return .failure(UBNetworkError.unableToDecode(String(describing: T.self), nil))
                     }
                 case let .success(data):
-                    // TODO: Implement mime type checking for JSON before attempting to decode JSON (IOS-1967)
-//                    // If the mime type for the response isn't JSON, we can't decode it
-//                    guard dataResponse.response?.mimeType == "application/json" else {
-//                        return .failure(UBNetworkError.invalidContentType(dataResponse.response?.mimeType ?? "unknown"))
-//                    }
+                    // If the mime type for the response isn't JSON, we can't decode it
+                    guard dataResponse.response?.mimeType == "application/json" else {
+                        return .failure(UBNetworkError.invalidContentType(dataResponse.response?.mimeType ?? "unknown"))
+                    }
                     
                     do {
                         let decodedObject = try decoder.decode(T.self, from: data)

--- a/Sources/UtilityBeltNetworking/HTTPClient.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient.swift
@@ -320,7 +320,7 @@ public class HTTPClient {
     ///   - response: The response to perform the validation on.
     ///   - validators: Additional validators on top of the default validators that should be applied to the response.
     /// - Throws: Throws any validation errors, indicating failed validation.
-    private func validate(response: HTTPURLResponse, with validators: [ResponseValidator]) throws {
+    func validate(response: HTTPURLResponse, with validators: [ResponseValidator]) throws {
         try (self.defaultValidators + validators).forEach { validator in
             try validator.validate(response: response)
         }

--- a/Sources/UtilityBeltNetworking/Models/MimeType.swift
+++ b/Sources/UtilityBeltNetworking/Models/MimeType.swift
@@ -1,5 +1,13 @@
 // Copyright © 2021 SpotHero, Inc. All rights reserved.
 
-public enum MimeType: String, Codable {
-    case json = "application/json"
+import Foundation
+
+public struct MimeType: RawRepresentable, Codable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public static let json: Self = MimeType(rawValue: "application/json")
 }

--- a/Sources/UtilityBeltNetworking/Models/MimeType.swift
+++ b/Sources/UtilityBeltNetworking/Models/MimeType.swift
@@ -1,0 +1,5 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+public enum MimeType: String, Codable {
+    case json = "application/json"
+}

--- a/Sources/UtilityBeltNetworking/Models/ResponseValidator.swift
+++ b/Sources/UtilityBeltNetworking/Models/ResponseValidator.swift
@@ -1,0 +1,45 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+/// A function that validates an HTTPURLResponse.  Throwing an error indicates a failed validation.
+public typealias ValidationBlock = (HTTPURLResponse) throws -> Void
+
+/// An object that can validate URL responses.
+public struct ResponseValidator {
+    // MARK: Properties
+
+    private let validationCheck: ValidationBlock
+
+    // MARK: Methods
+
+    func validate(response: HTTPURLResponse) throws {
+        try self.validationCheck(response)
+    }
+}
+
+// MARK: - Common Validators
+
+public extension ResponseValidator {
+    /// Creates a validator that will ensure the response has a specific mime type
+    /// - Parameter mimeType: The mime type we want to validate the existance of.
+    /// - Returns: The validator that will do this check.
+    static func ensureMimeType(_ mimeType: MimeType) -> ResponseValidator {
+        return ResponseValidator { response in
+            let responseMimeType = response.mimeType
+            if responseMimeType != mimeType.rawValue {
+                throw UBNetworkError.invalidContentType(responseMimeType ?? "unknown")
+            }
+        }
+    }
+    
+    /// Creates a validator that will ensure the response status code is not an error code.
+    /// - Returns: The validator that will do this check.
+    static let validateStatusCode = ResponseValidator { response in
+        let status = response.status
+        if status.responseType == .clientError || status.responseType == .serverError {
+            // TODO: Update with better error
+            throw UBNetworkError.unexpectedError
+        }
+    }
+}

--- a/Sources/UtilityBeltNetworking/Models/ResponseValidator.swift
+++ b/Sources/UtilityBeltNetworking/Models/ResponseValidator.swift
@@ -38,8 +38,7 @@ public extension ResponseValidator {
     static let validateStatusCode = ResponseValidator { response in
         let status = response.status
         if status.responseType == .clientError || status.responseType == .serverError {
-            // TODO: Update with better error
-            throw UBNetworkError.unexpectedError
+            throw UBNetworkError.invalidStatusCode(status)
         }
     }
 }


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-1967

**Description**
This is marked with proposal because I just wanted to get some feedback on the solutions here.  If we are simply checking the content type is `application/json` in the response handler, I think just uncommenting the existing code is fine for the non-combine request builders.  Are we trying to do more here, like match content types against any Accept headers if they are there?

Also, for implementing this on the combine version, I think we have a couple options.  
1) expose the full `URLSession.DataTaskPublisher.Output` down the chain
2) pass in some kind of validation to the base call site.  I wrote up a very quick example of what this could look like.

option 1 feels like better use of combine, but I think option 2 could works as well.

@bdrelling I was wondering a) why you originally commented out the guard statement? Just uncommenting it out makes me feel like I am missing something and b) what are your opinions on implementing a similar check in the combine version?