### PR TITLE
IOS-1428: Add case insensitivity to matching URL paths

### DIFF
--- a/Sources/Sham/Models/StubRequest.swift
+++ b/Sources/Sham/Models/StubRequest.swift
@@ -124,8 +124,8 @@ public struct StubRequest: Hashable, CustomStringConvertible, Codable {
         // Include any stubbed response where the port matches the incoming URL's port or is nil
         let validPort = url.port == nil || url.port == requestURL.port
         
-        // Include any stubbed response where the path matches the incoming URL's path or is empty
-        let validPath = url.trimmedPath.isEmpty || url.trimmedPath == requestURL.trimmedPath
+        // Include any stubbed response where the path matches the incoming URL's case insensitive path or is empty
+        let validPath = url.trimmedPath.isEmpty || url.trimmedPath.lowercased() == requestURL.trimmedPath.lowercased()
         
         // Determine if the stub and request have the same base URL.
         let hasSameBaseURL = validScheme && validHost && validPort && validPath

--- a/Tests/ShamTests/Tests/StubRequestTests.swift
+++ b/Tests/ShamTests/Tests/StubRequestTests.swift
@@ -53,4 +53,17 @@ final class StubRequestTests: XCTestCase {
         // THEN: The stub does not have all provided query items for the superset stub.
         XCTAssertFalse(querySupersetStub.hasSubsetOfQueryItems(in: stub))
     }
+    
+    func testDifferentCasedURLPathsStillMatch() {
+        let endpointString = "/aardvark=other_thing&zebra=thing"
+        
+        // GIVEN: A StubRequest with a lowercased endpoint
+        let lowercasedStub: StubRequest = .get("\(self.baseURLString)\(endpointString.lowercased())")
+        
+        // GIVEN: A StubRequest with the same endpoint but with uppercased letters
+        let uppercasedStub: StubRequest = .get("\(self.baseURLString)\(endpointString.uppercased())")
+        
+        // THEN: The lowercased StubRequest can still mock data for the uppercased StubRequest.
+        XCTAssertTrue(lowercasedStub.canMockData(for: uppercasedStub))
+    }
 }

--- a/Tests/ShamTests/Tests/StubRequestTests.swift
+++ b/Tests/ShamTests/Tests/StubRequestTests.swift
@@ -57,7 +57,7 @@ final class StubRequestTests: XCTestCase {
     func testDifferentCasedURLPathsStillMatch() {
         let endpointString = "/aardvark=other_thing&zebra=thing"
         
-        // GIVEN: A StubRequest with a lowercased endpoint
+        // GIVEN: A StubRequest with a lowercased path
         let lowercasedStub: StubRequest = .get("\(self.baseURLString)\(endpointString.lowercased())")
         
         // GIVEN: A StubRequest with the same endpoint but with uppercased letters

--- a/Tests/ShamTests/Tests/StubRequestTests.swift
+++ b/Tests/ShamTests/Tests/StubRequestTests.swift
@@ -60,7 +60,7 @@ final class StubRequestTests: XCTestCase {
         // GIVEN: A StubRequest with a lowercased path
         let lowercasedStub: StubRequest = .get("\(self.baseURLString)\(endpointString.lowercased())")
         
-        // GIVEN: A StubRequest with the same endpoint but with uppercased letters
+        // GIVEN: A StubRequest with the same path but with uppercased letters
         let uppercasedStub: StubRequest = .get("\(self.baseURLString)\(endpointString.uppercased())")
         
         // THEN: The lowercased StubRequest can still mock data for the uppercased StubRequest.


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-1428

**Description**
- Adds case insensitivity to matching URL paths.