### PR TITLE
IOS-3202: Feature/Adapting URL Requests

### DIFF
--- a/Sources/UtilityBeltNetworking/HTTPClient.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient.swift
@@ -273,7 +273,7 @@ public class HTTPClient {
 
 // MARK: - Extensions
 
-private extension DataResponse {
+internal extension DataResponse {
     /// Initializes a `DataResponse` object with `nil` request, response, and data properties
     /// and a failure result containing the given error.
     /// - Parameter error: The error to return in the result of the response.

--- a/Sources/UtilityBeltNetworking/HTTPClient.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient.swift
@@ -49,6 +49,7 @@ public class HTTPClient {
     /// - Parameter headers: The HTTP headers to send with the request.
     /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
     /// - Parameter validators: An array of validators that will be applied to the response.
+    /// - Parameter interceptor: An object that can intercept the url request. Defaults to `nil`.
     /// - Parameter dispatchQueue: The dispatch queue that the completion will be called on. Defaults to `.main`.
     /// - Parameter completion: The completion block to call when the request is completed.
     /// - Returns: The `URLSessionTask` for the request.
@@ -59,12 +60,13 @@ public class HTTPClient {
                         headers: HTTPHeaderDictionaryConvertible? = nil,
                         encoding: ParameterEncoding? = nil,
                         validators: [ResponseValidator] = [],
+                        interceptor: RequestInterceptor? = nil,
                         dispatchQueue: DispatchQueue = .main,
-                        completion: DataTaskCompletion? = nil) -> URLSessionTask? {
-        let request: URLRequest
+                        completion: DataTaskCompletion? = nil) -> Request? {
+        let urlRequest: URLRequest
         
         do {
-            request = try self.configuredURLRequest(
+            urlRequest = try self.configuredURLRequest(
                 url: url,
                 method: method,
                 parameters: parameters,
@@ -78,78 +80,16 @@ public class HTTPClient {
             return nil
         }
         
-        if let urlString = request.url?.absoluteString {
+        if let urlString = urlRequest.url?.absoluteString {
             self.log("Starting \(method.rawValue) request to \(urlString)")
         }
         
-        let completion: HTTPSessionDelegateCompletion = { data, urlResponse, error in
-            self.log("Request finished.")
-            
-            if let urlResponse = urlResponse {
-                self.log("[Response] \(urlResponse)")
-            }
-            
-            // Convert the URLResponse into an HTTPURLResponse object.
-            // If it cannot be converted, use the undefined HTTPURLResponse object
-            let httpResponse = urlResponse as? HTTPURLResponse
-            
-            // Create a result object for improved handling of the response
-            let result: Result<Data, Error> = {
-                if let response = httpResponse {
-                    do {
-                        for validator in validators {
-                            try validator.validate(response: response)
-                        }
-                    } catch {
-                        return .failure(error)
-                    }
-                }
-                if let data = data {
-                    return .success(data)
-                } else if let error = error {
-                    return .failure(error)
-                } else {
-                    return .failure(UBNetworkError.unexpectedError)
-                }
-            }()
-            
-            switch result {
-            case let .success(data):
-                self.log("Response succeeded.")
-                
-                // Attempt to get the data as pretty printed JSON, otherwise just encode to utf8
-                if let dataString: String = data.asPrettyPrintedJSON ?? String(data: data, encoding: .utf8) {
-                    self.log(dataString)
-                }
-            case let .failure(error):
-                self.log("Response failed. Error: \(error.localizedDescription)")
-            }
-            
-            // Create the DataResponse object containing all necessary information from the response
-            let dataResponse = DataResponse(request: request,
-                                            response: httpResponse,
-                                            data: data,
-                                            result: result)
-            
-            dispatchQueue.async {
-                // Fire the completion!
-                completion?(dataResponse)
-            }
-        }
-        
-        let task: URLSessionTask
-        // When a background request is made, it must use a delegate
-        // and be a download or upload task. Using a data task will fail
-        // and using a completion will cause an assertion failure.
-        if let delegate = self.session.delegate as? HTTPSessionDelegate {
-            delegate.completion = completion
-            task = self.session.downloadTask(with: request)
-        } else {
-            task = self.session.dataTask(with: request, completionHandler: completion)
-        }
-        task.resume()
-        
-        return task
+        let request = Request(urlRequest: urlRequest,
+                              session: self.session,
+                              interceptor: interceptor,
+                              completion: completion)
+        request.resume()
+        return request
     }
     
     /// Creates and sends a request which fetches raw data from an endpoint.
@@ -159,6 +99,7 @@ public class HTTPClient {
     /// - Parameter headers: The HTTP headers to send with the request.
     /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
     /// - Parameter validators: An array of validators that will be applied to the response.
+    /// - Parameter interceptor: An object that can intercept the url request. Defaults to `nil`.
     /// - Parameter dispatchQueue: The dispatch queue that the completion will be called on. Defaults to `.main`.
     /// - Parameter completion: The completion block to call when the request is completed.
     /// - Returns: The `URLSessionTask` for the request.
@@ -170,14 +111,16 @@ public class HTTPClient {
                         headers: HTTPHeaderDictionaryConvertible? = nil,
                         encoding: ParameterEncoding? = nil,
                         validators: [ResponseValidator] = [],
+                        interceptor: RequestInterceptor? = nil,
                         dispatchQueue: DispatchQueue = .main,
-                        completion: DataTaskCompletion? = nil) -> URLSessionTask? {
+                        completion: DataTaskCompletion? = nil) -> Request? {
         self.request(url,
                      method: method,
                      parameters: try? parameters.asDictionary(),
                      headers: headers,
                      encoding: encoding,
                      validators: validators,
+                     interceptor: interceptor,
                      dispatchQueue: dispatchQueue,
                      completion: completion)
     }
@@ -191,6 +134,7 @@ public class HTTPClient {
     /// - Parameter headers: The HTTP headers to send with the request.
     /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
     /// - Parameter validators: An array of validators that will be applied to the response. Defaults to ensuring a JSON mime type on the response.
+    /// - Parameter interceptor: An object that can intercept the url request. Defaults to `nil`.
     /// - Parameter dispatchQueue: The dispatch queue that the completion will be called on. Defaults to `.main`.
     /// - Parameter decoder: The `JSONDecoder` to use when decoding the response data.
     /// - Parameter completion: The completion block to call when the request is completed.
@@ -202,9 +146,10 @@ public class HTTPClient {
                                       headers: HTTPHeaderDictionaryConvertible? = nil,
                                       encoding: ParameterEncoding? = nil,
                                       validators: [ResponseValidator] = [.ensureMimeType(.json)],
+                                      interceptor: RequestInterceptor? = nil,
                                       dispatchQueue: DispatchQueue = .main,
                                       decoder: JSONDecoder = JSONDecoder(),
-                                      completion: DecodableTaskCompletion<T>? = nil) -> URLSessionTask? {
+                                      completion: DecodableTaskCompletion<T>? = nil) -> Request? {
         return self.request(
             url,
             method: method,
@@ -212,6 +157,7 @@ public class HTTPClient {
             headers: headers,
             encoding: encoding,
             validators: validators,
+            interceptor: interceptor,
             dispatchQueue: dispatchQueue
         ) { dataResponse in
             // Create a result object for improved handling of the response
@@ -256,6 +202,7 @@ public class HTTPClient {
     /// - Parameter headers: The HTTP headers to send with the request.
     /// - Parameter encoding: The parameter encoding method. If nil, uses the default encoding for the provided HTTP method.
     /// - Parameter validators: An array of validators that will be applied to the response. Defaults to ensuring a JSON mime type on the response.
+    /// - Parameter interceptor: An object that can intercept the url request. Defaults to `nil`.
     /// - Parameter dispatchQueue: The dispatch queue that the completion will be called on. Defaults to `.main`.
     /// - Parameter decoder: The `JSONDecoder` to use when decoding the response data.
     /// - Parameter completion: The completion block to call when the request is completed.
@@ -268,15 +215,17 @@ public class HTTPClient {
                                       headers: HTTPHeaderDictionaryConvertible? = nil,
                                       encoding: ParameterEncoding? = nil,
                                       validators: [ResponseValidator] = [.ensureMimeType(.json)],
+                                      interceptor: RequestInterceptor? = nil,
                                       dispatchQueue: DispatchQueue = .main,
                                       decoder: JSONDecoder = JSONDecoder(),
-                                      completion: DecodableTaskCompletion<T>? = nil) -> URLSessionTask? {
+                                      completion: DecodableTaskCompletion<T>? = nil) -> Request? {
         self.request(url,
                      method: method,
                      parameters: try? parameters.asDictionary(),
                      headers: headers,
                      encoding: encoding,
                      validators: validators,
+                     interceptor: interceptor,
                      dispatchQueue: dispatchQueue,
                      decoder: decoder,
                      completion: completion)

--- a/Sources/UtilityBeltNetworking/HTTPClient.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient.swift
@@ -86,7 +86,9 @@ public class HTTPClient {
         
         let request = Request(urlRequest: urlRequest,
                               session: self.session,
+                              validators: validators,
                               interceptor: interceptor,
+                              dispatchQueue: dispatchQueue,
                               completion: completion)
         request.resume()
         return request

--- a/Sources/UtilityBeltNetworking/Models/Request.swift
+++ b/Sources/UtilityBeltNetworking/Models/Request.swift
@@ -78,6 +78,11 @@ public class Request {
     
     /// Cancels the current task.
     public func cancel() {
+        // TODO: If a cancel request comes in prior to starting the task
+        // (e.x. if the adapt operation is taking awhile), how do we
+        // ensure the task doesn't start anyway and that the proper
+        // cancellation error is returned?
+        // https://spothero.atlassian.net/browse/IOS-3202
         self.task?.cancel()
     }
     

--- a/Sources/UtilityBeltNetworking/Models/Request.swift
+++ b/Sources/UtilityBeltNetworking/Models/Request.swift
@@ -61,7 +61,7 @@ public class Request {
             currentTask.resume()
         } else if let interceptor = self.interceptor {
             // If there is not an existing task, and there's a RequestInterceptor,
-            // pass the request off to be adapted, then kick off the request.
+            // pass the request off to be adapted, then create start the task.
             interceptor.adapt(self.initialURLRequest) { result in
                 switch result {
                 case let .success(adaptedRequest):

--- a/Sources/UtilityBeltNetworking/Models/Request.swift
+++ b/Sources/UtilityBeltNetworking/Models/Request.swift
@@ -1,0 +1,173 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+public class Request {
+    // MARK: Properties
+    
+    /// The initial URL request when the `Request` object was created.
+    /// This may differ from the final URL request sent to the server
+    /// if a `RequestAdapter` is used.
+    private let initialURLRequest: URLRequest
+    
+    /// The session in which the request will be made.
+    private let session: URLSession
+    
+    /// The current session task.
+    private var task: URLSessionTask?
+    
+    /// An array of validators that will be applied to the response.
+    private let validators: [ResponseValidator]
+    
+    /// An object that can intercept the url request.
+    private let interceptor: RequestInterceptor?
+    
+    /// The block to call when the request has completed.
+    private let completion: DataTaskCompletion?
+    
+    /// The dispatch queue that the completion will be called on.
+    private let dispatchQueue: DispatchQueue
+    
+    // MARK: Initialization
+    
+    /// Create a new instance of a `Request`.
+    /// - Parameters:
+    ///   - urlRequest: The URL for the request.
+    ///   - session: The session in which the request will be made.
+    ///   - validators: An array of validators that will be applied to the response. Defaults to an empty array.
+    ///   - interceptor: An object that can intercept the url request. Defaults to `nil`.
+    ///   - dispatchQueue: The dispatch queue that the completion will be called on. Defaults to `.main`.
+    ///   - completion: The block to call when the request has completed. Defaults to `nil`.
+    public init(urlRequest: URLRequest,
+                session: URLSession,
+                validators: [ResponseValidator] = [],
+                interceptor: RequestInterceptor? = nil,
+                dispatchQueue: DispatchQueue = .main,
+                completion: DataTaskCompletion? = nil) {
+        self.initialURLRequest = urlRequest
+        self.session = session
+        self.validators = validators
+        self.interceptor = interceptor
+        self.dispatchQueue = dispatchQueue
+        self.completion = completion
+    }
+
+    // MARK: Updating State
+    
+    /// Resumes the current task.
+    public func resume() {
+        if let currentTask = self.task {
+            // If there's an existing task, resume that task.
+            currentTask.resume()
+        } else if let interceptor = self.interceptor {
+            // If there is not an existing task, and there's a RequestInterceptor,
+            // pass the request off to be adapted, then kick off the request.
+            interceptor.adapt(self.initialURLRequest) { result in
+                switch result {
+                case let .success(adaptedRequest):
+                    self.performSessionTask(with: adaptedRequest)
+                case let .failure(error):
+                    self.completion?(.failure(error))
+                }
+            }
+        } else {
+            // Otherwise, create and start the task.
+            self.performSessionTask(with: self.initialURLRequest)
+        }
+    }
+    
+    /// Cancels the current task.
+    public func cancel() {
+        self.task?.cancel()
+    }
+    
+    /// Suspends the current task.
+    public func suspend() {
+        self.task?.suspend()
+    }
+    
+    /// Creates and starts a session task with the given URL request.
+    /// - Parameter urlRequest: The URL for the request.
+    private func performSessionTask(with urlRequest: URLRequest) {
+        let wrappedCompletion: HTTPSessionDelegateCompletion = { data, response, error in
+            self.handleCompletedDataTask(originalURLRequest: urlRequest,
+                                         data: data,
+                                         urlResponse: response,
+                                         error: error)
+        }
+        
+        let task: URLSessionTask
+        // When a background request is made, it must use a delegate
+        // and be a download or upload task. Using a data task will fail
+        // and using a completion will cause an assertion failure.
+        if let delegate = self.session.delegate as? HTTPSessionDelegate {
+            delegate.completion = wrappedCompletion
+            task = self.session.downloadTask(with: urlRequest)
+        } else {
+            task = self.session.dataTask(with: urlRequest, completionHandler: wrappedCompletion)
+        }
+
+        self.task = task
+        task.resume()
+    }
+    
+    // MARK: Response Handling
+    
+    private func handleCompletedDataTask(originalURLRequest: URLRequest,
+                                         data: Data?,
+                                         urlResponse: URLResponse?,
+                                         error: Error?) {
+        HTTPClient.shared.log("Request finished.")
+        
+        if let urlResponse = urlResponse {
+            HTTPClient.shared.log("[Response] \(urlResponse)")
+        }
+        
+        // Convert the URLResponse into an HTTPURLResponse object.
+        // If it cannot be converted, use the undefined HTTPURLResponse object
+        let httpResponse = urlResponse as? HTTPURLResponse
+        
+        // Create a result object for improved handling of the response
+        let result: Result<Data, Error> = {
+            if let response = httpResponse {
+                do {
+                    for validator in validators {
+                        try validator.validate(response: response)
+                    }
+                } catch {
+                    return .failure(error)
+                }
+            }
+            if let data = data {
+                return .success(data)
+            } else if let error = error {
+                return .failure(error)
+            } else {
+                return .failure(UBNetworkError.unexpectedError)
+            }
+        }()
+        
+        switch result {
+        case let .success(data):
+            HTTPClient.shared.log("Response succeeded.")
+            
+            // Attempt to get the data as pretty printed JSON, otherwise just encode to utf8
+            if let dataString: String = data.asPrettyPrintedJSON ?? String(data: data, encoding: .utf8) {
+                HTTPClient.shared.log(dataString)
+            }
+        case let .failure(error):
+            HTTPClient.shared.log("Response failed. Error: \(error.localizedDescription)")
+        }
+        
+        // Create the DataResponse object containing all necessary information from the response
+        let dataResponse = DataResponse(request: originalURLRequest,
+                                        response: httpResponse,
+                                        data: data,
+                                        result: result)
+        
+        self.dispatchQueue.async {
+            // Fire the completion!
+            self.completion?(dataResponse)
+        }
+    }
+}

--- a/Sources/UtilityBeltNetworking/Protocols/RequestAdapter.swift
+++ b/Sources/UtilityBeltNetworking/Protocols/RequestAdapter.swift
@@ -1,0 +1,12 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+public protocol RequestAdapter {
+    /// Allows for adapting a `URLRequest` prior to the request being sent to the server.
+    /// - Parameters:
+    ///   - request: The `URLRequest` to adapt.
+    ///   - completion: A closure that must be executed when request adapting is complete. If you
+    /// do not wish to adapt the request, call the closure with a `.success`, passing in the original request.
+    func adapt(_ request: URLRequest, completion: (Swift.Result<URLRequest, Error>) -> Void)
+}

--- a/Sources/UtilityBeltNetworking/Protocols/RequestInterceptor.swift
+++ b/Sources/UtilityBeltNetworking/Protocols/RequestInterceptor.swift
@@ -1,0 +1,5 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+public protocol RequestInterceptor: RequestAdapter {}

--- a/Tests/UtilityBeltNetworkingTests/Tests/RequestAdapterTests.swift
+++ b/Tests/UtilityBeltNetworkingTests/Tests/RequestAdapterTests.swift
@@ -1,0 +1,77 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+import Foundation
+@testable import UtilityBeltNetworking
+import XCTest
+
+final class RequestAdapterTests: XCTestCase {
+    // MARK: Lifecycle
+    
+    override class func setUp() {
+        super.setUp()
+        // Set a short timeout to avoid waiting on requests to complete.
+        HTTPClient.shared.timeoutInterval = 0.1
+    }
+    
+    override class func tearDown() {
+        // Reset the timeout interval.
+        HTTPClient.shared.timeoutInterval = nil
+        super.tearDown()
+    }
+    
+    // MARK: Tests
+    
+    func testAdaptedURLIsReturnedInDataResponse() {
+        // Create an adapter that changes the original request.
+        struct MockAdapter: RequestInterceptor {
+            static let adaptedURL = "https//www.spothero.com/foo"
+            func adapt(_ request: URLRequest,
+                       completion: (Result<URLRequest, Error>) -> Void) {
+                var adaptedRequest = request
+                adaptedRequest.url = URL(string: Self.adaptedURL)
+                completion(.success(adaptedRequest))
+            }
+        }
+        
+        let interceptor = MockAdapter()
+        
+        // Start a request for the initial URL.
+        let expectation = self.expectation(description: "Request has completed")
+        let initialURL = "https//www.spothero.com"
+        HTTPClient.shared.request(initialURL, interceptor: interceptor) { response in
+            // Verify the response returns the adapted URL.
+            XCTAssertEqual(response.request?.url?.absoluteString, MockAdapter.adaptedURL)
+            expectation.fulfill()
+        }
+        
+        self.wait(for: [expectation], timeout: 1)
+    }
+    
+    func testErrorDuringRequestAdaptingIsReturnedInDataResponse() {
+        // Create an adapter that returns an error.
+        struct MockAdapter: RequestInterceptor {
+            static let errorDescription = "Adapting url failed"
+            func adapt(_ request: URLRequest,
+                       completion: (Result<URLRequest, Error>) -> Void) {
+                let error = NSError(domain: "testing.domain",
+                                    code: 0,
+                                    userInfo: [NSLocalizedDescriptionKey: Self.errorDescription])
+                completion(.failure(error))
+            }
+        }
+        
+        let interceptor = MockAdapter()
+        
+        // Start a request.
+        let expectation = self.expectation(description: "Request has completed")
+        let url = "https//www.spothero.com"
+        HTTPClient.shared.request(url, interceptor: interceptor) { response in
+            // Verify the response returns the error from the adapter.
+            XCTAssertEqual(response.error?.localizedDescription,
+                           MockAdapter.errorDescription)
+            expectation.fulfill()
+        }
+        
+        self.wait(for: [expectation], timeout: 1)
+    }
+}


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-3202

**Description**
This is the first half of changes that will eventually allow for the ability to handle tasks such as renewing access tokens upon receiving a 401 from the server and retying a request with a refreshed access token before failing completely.

To achieve this, I'm planning the following:
- Create a `RequestAdapter` protocol which will allow clients to make changes to a request before it is sent to the server (e.x. add an `Authorization` header to the request with the proper credentials)
- Create a `RequestRetrier` protocol which will allow clients to see why a request failed and tell the HTTPClient whether or not it should retry to request (e.x. If the status code was 401, try renewing our access token and storing it. Then, when the request is retried, it'll call the `RequestAdapter` which can add the updated access token to the headers.)

This PR covers the first bullet point, in which I:
- Added the `RequestAdapter` protocol
- Changed the return type of our `HTTPClient` methods to use a new `Request` object. This is due to adapting the request being an async process and eventually become retrying will result in a new `URLSessionTask` being created
- Give the client the opportunity to adapt the URLRequest prior to starting the task

**Note: This is going into an aggregate branch until the retry logic is completed as well.**