### PR TITLE
IOS-3202: Feature/Retrying Requests

### DIFF
--- a/Sources/UtilityBeltNetworking/HTTPClient.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient.swift
@@ -84,13 +84,12 @@ public class HTTPClient {
             self.log("Starting \(method.rawValue) request to \(urlString)")
         }
         
-        let request = Request(urlRequest: urlRequest,
-                              session: self.session,
+        let request = Request(session: self.session,
                               validators: validators,
                               interceptor: interceptor,
                               dispatchQueue: dispatchQueue,
                               completion: completion)
-        request.resume()
+        request.perform(urlRequest: urlRequest)
         return request
     }
     

--- a/Sources/UtilityBeltNetworking/Models/Request.swift
+++ b/Sources/UtilityBeltNetworking/Models/Request.swift
@@ -47,7 +47,10 @@ public class Request {
         self.completion = completion
     }
     
+    /// Creates a new `URLSessionTask` from the given `URLRequest` and resumes the task.
+    /// - Parameter urlRequest: The request to be sent to the server.
     func perform(urlRequest: URLRequest) {
+        // Wrap the logic to create and resume the task in a reusable method.
         func createAndResumeSessionTask(with urlRequest: URLRequest) {
             let wrappedCompletion: HTTPSessionDelegateCompletion = { data, response, error in
                 self.processCompletedTask(urlRequest: urlRequest,
@@ -72,8 +75,8 @@ public class Request {
         }
         
         if let interceptor = self.interceptor {
-            // If there is not an existing task, and there's a RequestInterceptor,
-            // pass the request off to be adapted, then create resume the task.
+            // If there's a RequestInterceptor, pass the request
+            // off to be adapted, then create resume the task.
             interceptor.adapt(urlRequest) { result in
                 switch result {
                 case let .success(adaptedRequest):

--- a/Sources/UtilityBeltNetworking/Models/Request.swift
+++ b/Sources/UtilityBeltNetworking/Models/Request.swift
@@ -58,7 +58,7 @@ public final class Request {
             interceptor.adapt(urlRequest) { result in
                 switch result {
                 case let .success(adaptedRequest):
-                    createAndResumeSessionTask(with: adaptedRequest)
+                    self.createAndResumeSessionTask(with: adaptedRequest)
                 case let .failure(error):
                     self.completion?(.failure(error))
                 }

--- a/Sources/UtilityBeltNetworking/Models/Request.swift
+++ b/Sources/UtilityBeltNetworking/Models/Request.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-public class Request {
+public final class Request {
     // MARK: Properties
     
     /// The session in which the request will be made.

--- a/Sources/UtilityBeltNetworking/Protocols/RequestAdapter.swift
+++ b/Sources/UtilityBeltNetworking/Protocols/RequestAdapter.swift
@@ -8,5 +8,5 @@ public protocol RequestAdapter {
     ///   - request: The `URLRequest` to adapt.
     ///   - completion: A closure that must be executed when request adapting is complete. If you
     /// do not wish to adapt the request, call the closure with a `.success`, passing in the original request.
-    func adapt(_ request: URLRequest, completion: (Swift.Result<URLRequest, Error>) -> Void)
+    func adapt(_ request: URLRequest, completion: @escaping (Swift.Result<URLRequest, Error>) -> Void)
 }

--- a/Sources/UtilityBeltNetworking/Protocols/RequestInterceptor.swift
+++ b/Sources/UtilityBeltNetworking/Protocols/RequestInterceptor.swift
@@ -2,4 +2,4 @@
 
 import Foundation
 
-public protocol RequestInterceptor: RequestAdapter {}
+public protocol RequestInterceptor: RequestAdapter, RequestRetrier {}

--- a/Sources/UtilityBeltNetworking/Protocols/RequestRetrier.swift
+++ b/Sources/UtilityBeltNetworking/Protocols/RequestRetrier.swift
@@ -8,5 +8,5 @@ public protocol RequestRetrier {
     ///   - request: The `Request` containing the `URLSessionTask` that failed.
     ///   - error: The error that triggered the call to retry.
     ///   - completion: A closure to indicate whether or not the request should be retried.
-    func retry(_ request: Request, dueTo error: Error, completion: (Bool) -> Void)
+    func retry(_ request: Request, dueTo error: Error, completion: @escaping (Bool) -> Void)
 }

--- a/Sources/UtilityBeltNetworking/Protocols/RequestRetrier.swift
+++ b/Sources/UtilityBeltNetworking/Protocols/RequestRetrier.swift
@@ -1,0 +1,12 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+public protocol RequestRetrier {
+    /// Allows for inspection of a failed request and determines if the request should be retried.
+    /// - Parameters:
+    ///   - request: The `Request` containing the `URLSessionTask` that failed.
+    ///   - error: The error that triggered the call to retry.
+    ///   - completion: A closure to indicate whether or not the request should be retried.
+    func retry(_ request: Request, dueTo error: Error, completion: (Bool) -> Void)
+}

--- a/Tests/UtilityBeltNetworkingTests/Tests/RequestInterceptorTests.swift
+++ b/Tests/UtilityBeltNetworkingTests/Tests/RequestInterceptorTests.swift
@@ -4,7 +4,7 @@ import Foundation
 @testable import UtilityBeltNetworking
 import XCTest
 
-final class RequestAdapterTests: XCTestCase {
+final class RequestInterceptorTests: XCTestCase {
     // MARK: Lifecycle
     
     override class func setUp() {
@@ -19,7 +19,7 @@ final class RequestAdapterTests: XCTestCase {
         super.tearDown()
     }
     
-    // MARK: Tests
+    // MARK: RequestAdapter Tests
     
     func testAdaptedURLIsReturnedInDataResponse() {
         // Create an adapter that changes the original request.
@@ -30,6 +30,10 @@ final class RequestAdapterTests: XCTestCase {
                 var adaptedRequest = request
                 adaptedRequest.url = URL(string: Self.adaptedURL)
                 completion(.success(adaptedRequest))
+            }
+            
+            func retry(_ request: Request, dueTo error: Error, completion: (Bool) -> Void) {
+                completion(false)
             }
         }
         
@@ -57,6 +61,10 @@ final class RequestAdapterTests: XCTestCase {
                                     code: 0,
                                     userInfo: [NSLocalizedDescriptionKey: Self.errorDescription])
                 completion(.failure(error))
+            }
+            
+            func retry(_ request: Request, dueTo error: Error, completion: (Bool) -> Void) {
+                completion(false)
             }
         }
         

--- a/Tests/UtilityBeltNetworkingTests/Tests/RequestTests.swift
+++ b/Tests/UtilityBeltNetworkingTests/Tests/RequestTests.swift
@@ -33,9 +33,9 @@ final class RequestTests: XCTestCase {
         }
         
         // Perform the request.
-        let initialURL = "spothero.com"
+        let initialURL = "https://spothero.com"
         XCTAssertNotEqual(initialURL, MockAdapter.adaptedURL)
-        request.perform(urlRequest: try self.urlRequest(url: "spothero.com"))
+        request.perform(urlRequest: try self.urlRequest(url: initialURL))
         
         // Verify the expectation is met.
         self.wait(for: [expectation], timeout: 1)
@@ -70,7 +70,7 @@ final class RequestTests: XCTestCase {
         }
         
         // Perform the request.
-        request.perform(urlRequest: try self.urlRequest(url: "spothero.com"))
+        request.perform(urlRequest: try self.urlRequest(url: "https://spothero.com"))
         
         // Verify the expectation is met.
         self.wait(for: [expectation], timeout: 1)
@@ -104,7 +104,7 @@ final class RequestTests: XCTestCase {
         
         // Perform the request.
         let request = Request(session: .shared, interceptor: interceptor) { _ in }
-        request.perform(urlRequest: try self.urlRequest(url: "spothero.com"))
+        request.perform(urlRequest: try self.urlRequest(url: "https://spothero.com"))
         
         // Verify that the retry expectation was called.
         self.wait(for: [retryExpectation], timeout: 1)
@@ -143,7 +143,7 @@ final class RequestTests: XCTestCase {
         let request = Request(session: .shared, interceptor: interceptor) { _ in
             requestExpectation.fulfill()
         }
-        request.perform(urlRequest: try self.urlRequest(url: "spothero.com"))
+        request.perform(urlRequest: try self.urlRequest(url: "https://spothero.com"))
         
         // Verify retry occurred multiple times yet the request completion was only invoked once.
         self.wait(for: [retryExpectation, requestExpectation], timeout: 2)

--- a/Tests/UtilityBeltNetworkingTests/Tests/RequestTests.swift
+++ b/Tests/UtilityBeltNetworkingTests/Tests/RequestTests.swift
@@ -10,7 +10,7 @@ final class RequestTests: XCTestCase {
     func testAdaptedURLIsReturnedInDataResponse() throws {
         // Create an adapter that changes the original request.
         struct MockAdapter: RequestInterceptor {
-            static let adaptedURL = "spothero.com/foo"
+            static let adaptedURL = "https://spothero.com/foo"
             func adapt(_ request: URLRequest,
                        completion: (Result<URLRequest, Error>) -> Void) {
                 var adaptedRequest = request


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-3202

**Description**
Adds the ability to retry a request if it failed or fails validation.
- Added the `RequestRetrier` protocol and updated `RequestInterceptor` to conform to it
- Call the `RequestRetrier` when a task completes and either fails or does not pass validation, which will allow for a new request to be attempted
- Handled TODO around cancelling/suspending tasks while the `RequestInterceptor` is being called to ensure the cancellation or suspension request is upheld after returning from those async methods
- Moved existing `RequestAdapter` tests into a new test file named `RequestTests` and use a `Request` object directly instead of going through the `HTTPClient`
- Added new tests centered around retrying requests