### PR TITLE
Update to Xcode 13, iOS 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   lint:
     name: Lint
-    runs-on: macos-latest
+    runs-on: macos-11
     permissions:
       pull-requests: write
     env:
@@ -32,7 +32,7 @@ jobs:
         run: sh ./scripts/danger_lint.sh
   iOS:
     name: iOS ${{ matrix.os }} ${{ matrix.device_name }}
-    runs-on: macos-latest
+    runs-on: macos-11
     needs: [lint]
     strategy:
       matrix:
@@ -53,7 +53,7 @@ jobs:
           path: ${{ env.DEPLOY_DIRECTORY }}
   macOS:
     name: macOS
-    runs-on: macos-latest
+    runs-on: macos-11
     needs: [lint]
     steps:
       - name: Checkout
@@ -67,7 +67,7 @@ jobs:
           path: ${{ env.DEPLOY_DIRECTORY }}
   tvOS:
     name: tvOS ${{ matrix.os }} ${{ matrix.device_name }}
-    runs-on: macos-latest
+    runs-on: macos-11
     needs: [lint]
     strategy:
       matrix:
@@ -89,7 +89,7 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [macos-11]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Switch Xcode Version
-        run: xcode-select -switch "/Applications/Xcode_13.0.app"
+        run: sudo xcode-select -switch "/Applications/Xcode_13.0.app"
       - name: Run Tests
         run: sh ./scripts/xcode_build.sh "name=${{ matrix.device_name }},OS=${{ matrix.os }},platform=iOS Simulator"
       - name: Upload Step Output
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Switch Xcode Version
-        run: xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
+        run: sudo xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests
         run: sh ./scripts/xcode_build.sh "platform=macOS"
       - name: Upload Step Output
@@ -78,7 +78,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Switch Xcode Version
-        run: xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
+        run: sudo xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests
         run: sh ./scripts/xcode_build.sh "name=${{ matrix.device_name }},OS=${{ matrix.os }},platform=tvOS Simulator"
       - name: Upload Step Output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   PACKAGE_NAME: UtilityBelt
   XCODEBUILD_WORKSPACE: UtilityBelt.xcworkspace
   XCODEBUILD_SCHEME: UtilityBelt
-  DEVELOPER_DIR: /Applications/Xcode_13.0.app
+  DEVELOPER_DIR: /Applications/Xcode_13.0.app/Contents/Developer
   DEPLOY_DIRECTORY: deploy
 
 jobs:
@@ -40,7 +40,7 @@ jobs:
         os: [15.0]
         xcode_version: [13.0]
     env:
-      DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app"
+      DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   PACKAGE_NAME: UtilityBelt
   XCODEBUILD_WORKSPACE: UtilityBelt.xcworkspace
   XCODEBUILD_SCHEME: UtilityBelt
-  DEVELOPER_DIR: /Applications/Xcode_13.0.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_13.0.app
   DEPLOY_DIRECTORY: deploy
 
 jobs:
@@ -40,7 +40,7 @@ jobs:
         os: [15.0]
         xcode_version: [13.0]
     env:
-      DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer"
+      DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   PACKAGE_NAME: UtilityBelt
   XCODEBUILD_WORKSPACE: UtilityBelt.xcworkspace
   XCODEBUILD_SCHEME: UtilityBelt
-  DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_13.0.app/Contents/Developer
   DEPLOY_DIRECTORY: deploy
 
 jobs:
@@ -37,8 +37,8 @@ jobs:
     strategy:
       matrix:
         device_name: ["iPhone 12 Pro", "iPad Pro (11-inch) (2nd generation)"]
-        os: [14.4]
-        xcode_version: [12.4]
+        os: [15.0]
+        xcode_version: [13.0]
     env:
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer"
     steps:
@@ -72,7 +72,7 @@ jobs:
     strategy:
       matrix:
         device_name: ["Apple TV 4K"]
-        os: [14.3]
+        os: [15.0]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         os: [15.0]
         xcode_version: [13.0]
     env:
-      DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app
+      DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Switch Xcode Version
-        run: xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
+        run: xcode-select -switch "/Applications/Xcode_13.0.app"
       - name: Run Tests
         run: sh ./scripts/xcode_build.sh "name=${{ matrix.device_name }},OS=${{ matrix.os }},platform=iOS Simulator"
       - name: Upload Step Output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   PACKAGE_NAME: UtilityBelt
   XCODEBUILD_WORKSPACE: UtilityBelt.xcworkspace
   XCODEBUILD_SCHEME: UtilityBelt
-  DEVELOPER_DIR: /Applications/Xcode_13.0.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_13.0.app
   DEPLOY_DIRECTORY: deploy
 
 jobs:
@@ -40,7 +40,7 @@ jobs:
         os: [15.0]
         xcode_version: [13.0]
     env:
-      DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer"
+      DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,13 @@ jobs:
     strategy:
       matrix:
         device_name: ["iPhone 12 Pro", "iPad Pro (11-inch) (2nd generation)"]
-        os: [15.0]
-        xcode_version: [13.0]
+        os: ["15.0"]
+        xcode_version: ["13.0"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Switch Xcode Version
-        run: sudo xcode-select -switch "/Applications/Xcode_13.0.app"
+        run: sudo xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests
         run: sh ./scripts/xcode_build.sh "name=${{ matrix.device_name }},OS=${{ matrix.os }},platform=iOS Simulator"
       - name: Upload Step Output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ env:
   PACKAGE_NAME: UtilityBelt
   XCODEBUILD_WORKSPACE: UtilityBelt.xcworkspace
   XCODEBUILD_SCHEME: UtilityBelt
-  DEVELOPER_DIR: /Applications/Xcode_13.0.app
   DEPLOY_DIRECTORY: deploy
 
 jobs:
@@ -39,11 +38,11 @@ jobs:
         device_name: ["iPhone 12 Pro", "iPad Pro (11-inch) (2nd generation)"]
         os: [15.0]
         xcode_version: [13.0]
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Switch Xcode Version
+        run: xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests
         run: sh ./scripts/xcode_build.sh "name=${{ matrix.device_name }},OS=${{ matrix.os }},platform=iOS Simulator"
       - name: Upload Step Output
@@ -58,6 +57,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Switch Xcode Version
+        run: xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests
         run: sh ./scripts/xcode_build.sh "platform=macOS"
       - name: Upload Step Output
@@ -76,6 +77,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Switch Xcode Version
+        run: xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests
         run: sh ./scripts/xcode_build.sh "name=${{ matrix.device_name }},OS=${{ matrix.os }},platform=tvOS Simulator"
       - name: Upload Step Output
@@ -93,6 +96,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Switch Xcode Version
+        run: xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests
         run: sh ./scripts/swift_build.sh
       - name: Upload Step Output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
     name: macOS
     runs-on: macos-11
     needs: [lint]
+    strategy:
+      matrix:
+        xcode_version: ["13.0"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -73,7 +76,8 @@ jobs:
     strategy:
       matrix:
         device_name: ["Apple TV 4K"]
-        os: [15.0]
+        os: ["15.0"]
+        xcode_version: ["13.0"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -93,11 +97,12 @@ jobs:
     strategy:
       matrix:
         os: [macos-11]
+        xcode_version: ["13.0"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Switch Xcode Version
-        run: xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
+        run: sudo xcode-select -switch "/Applications/Xcode_${{ matrix.xcode_version }}.app"
       - name: Run Tests
         run: sh ./scripts/swift_build.sh
       - name: Upload Step Output


### PR DESCRIPTION
**Description**
Updating our GitHub Actions YAML to use Xcode 13 and iOS/tvOS 15. 
- I removed the `DEVELOPER_DIR: /Applications/Xcode_13.0.app/Contents/Developer` line as I was getting errors about that directory not existing
- Changed ` macos-latest` to `macos-11` as "latest" was not using Big Sur
- Added a line in each workflow to manually switch to the new version of Xcode using `xcode-select` (When searching for how to set the Xcode version in Github Actions YAML, not much documentation exists and I can't find anything on the `DEVELOPER_DIR` environment variable, but I've seen other repos using the `xcode-select` method and it seems a bit more straightforward