### PR TITLE
Feature/Bump iOS target to iOS 11

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ import PackageDescription
 let package = Package(
     name: "UtilityBelt",
     platforms: [
-        .iOS(.v10),         // supports NSPersistentContainer
+        .iOS(.v11),         // supports compilation on targets including armv7 and i386 architectures
         .macOS(.v10_12),    // supports NSPersistentContainer
         .tvOS(.v10),        // supports NSPersistentContainer
         .watchOS(.v3),      // supports NSPersistentContainer


### PR DESCRIPTION
**Description**
Bumps the iOS target from iOS 10 to 11 due to the following issue (noted in the Xcode 13 release notes):

> Swift libraries depending on Combine may fail to build for targets including armv7 and i386 architectures. (82183186, 82189214)
Workaround: Use an updated version of the library that isn’t impacted (if available) or remove armv7 and i386 support (for example, increase the deployment target of the library to iOS 11 or higher).

Additionally, from the [Apple Developer Forums:](https://developer.apple.com/forums/thread/682285)
> Generally speaking for the Xcode 13 RC, there are known issues specific to apps using libraries with a deployment target that still supports 32-bit iOS versions (iOS 10 or before), even if the app target only supports 64-bit iOS versions (iOS 11 and newer). To workaround this build error, move the library deployment target up to at least iOS 11.
These known issues and workarounds are also noted in the Xcode 13 Release Notes, under the Swift section.
