### PR TITLE
Added Data in RequestRetrier.retry

### DIFF
--- a/Sources/UtilityBeltNetworking/Models/Request.swift
+++ b/Sources/UtilityBeltNetworking/Models/Request.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 import Foundation
 

--- a/Sources/UtilityBeltNetworking/Models/Request.swift
+++ b/Sources/UtilityBeltNetworking/Models/Request.swift
@@ -212,7 +212,7 @@ public final class Request {
             HTTPClient.shared.log("Response failed. Error: \(error.localizedDescription)")
             
             if let interceptor = self.interceptor {
-                interceptor.retry(self, dueTo: error) { shouldRetry in
+                interceptor.retry(self, dueTo: error, data: data) { shouldRetry in
                     if shouldRetry {
                         // If we should retry, bump the retry count and perform the request again.
                         self.retryCount += 1

--- a/Sources/UtilityBeltNetworking/Protocols/RequestRetrier.swift
+++ b/Sources/UtilityBeltNetworking/Protocols/RequestRetrier.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 import Foundation
 

--- a/Sources/UtilityBeltNetworking/Protocols/RequestRetrier.swift
+++ b/Sources/UtilityBeltNetworking/Protocols/RequestRetrier.swift
@@ -7,6 +7,7 @@ public protocol RequestRetrier {
     /// - Parameters:
     ///   - request: The `Request` containing the `URLSessionTask` that failed.
     ///   - error: The error that triggered the call to retry.
+    ///   - data: The response data received from the request, if any.
     ///   - completion: A closure to indicate whether or not the request should be retried.
-    func retry(_ request: Request, dueTo error: Error, completion: @escaping (Bool) -> Void)
+    func retry(_ request: Request, dueTo error: Error, data: Data?, completion: @escaping (Bool) -> Void)
 }

--- a/Tests/UtilityBeltNetworkingTests/Tests/RequestTests.swift
+++ b/Tests/UtilityBeltNetworkingTests/Tests/RequestTests.swift
@@ -47,7 +47,7 @@ final class RequestTests: XCTestCase {
                 }
             }
             
-            func retry(_ request: Request, dueTo error: Error, completion: (Bool) -> Void) {
+            func retry(_ request: Request, dueTo error: Error, data: Data?, completion: (Bool) -> Void) {
                 completion(false)
             }
         }
@@ -78,7 +78,7 @@ final class RequestTests: XCTestCase {
             
             var retryBeganExpectation: XCTestExpectation?
             
-            func retry(_ request: Request, dueTo error: Error, completion: @escaping (Bool) -> Void) {
+            func retry(_ request: Request, dueTo error: Error, data: Data?, completion: @escaping (Bool) -> Void) {
                 guard request.retryCount < 1 else {
                     completion(false)
                     return
@@ -160,7 +160,7 @@ final class RequestTests: XCTestCase {
                 completion(.failure(error))
             }
             
-            func retry(_ request: Request, dueTo error: Error, completion: (Bool) -> Void) {
+            func retry(_ request: Request, dueTo error: Error, data: Data?, completion: (Bool) -> Void) {
                 completion(false)
             }
         }
@@ -194,7 +194,7 @@ final class RequestTests: XCTestCase {
             
             var retryExpectation: XCTestExpectation?
             
-            func retry(_ request: Request, dueTo error: Error, completion: (Bool) -> Void) {
+            func retry(_ request: Request, dueTo error: Error, data: Data?, completion: (Bool) -> Void) {
                 if request.retryCount < 1 {
                     completion(true)
                     self.retryExpectation?.fulfill()
@@ -230,7 +230,7 @@ final class RequestTests: XCTestCase {
             
             var retryExpectation: XCTestExpectation?
             
-            func retry(_ request: Request, dueTo error: Error, completion: (Bool) -> Void) {
+            func retry(_ request: Request, dueTo error: Error, data: Data?, completion: (Bool) -> Void) {
                 if request.retryCount < 3 {
                     completion(true)
                     self.retryExpectation?.fulfill()
@@ -271,7 +271,7 @@ final class RequestTests: XCTestCase {
                 }
             }
             
-            func retry(_ request: Request, dueTo error: Error, completion: (Bool) -> Void) {
+            func retry(_ request: Request, dueTo error: Error, data: Data?, completion: (Bool) -> Void) {
                 completion(false)
             }
         }
@@ -309,7 +309,7 @@ final class RequestTests: XCTestCase {
             
             var asyncRetryOperationStartedExpectation: XCTestExpectation?
             
-            func retry(_ request: Request, dueTo error: Error, completion: @escaping (Bool) -> Void) {
+            func retry(_ request: Request, dueTo error: Error, data: Data?, completion: @escaping (Bool) -> Void) {
                 guard request.retryCount < 1 else {
                     completion(false)
                     return

--- a/Tests/UtilityBeltNetworkingTests/Tests/RequestTests.swift
+++ b/Tests/UtilityBeltNetworkingTests/Tests/RequestTests.swift
@@ -124,7 +124,7 @@ final class RequestTests: XCTestCase {
                 completion(.success(adaptedRequest))
             }
             
-            func retry(_ request: Request, dueTo error: Error, completion: (Bool) -> Void) {
+            func retry(_ request: Request, dueTo error: Error, data: Data?, completion: (Bool) -> Void) {
                 completion(false)
             }
         }

--- a/Tests/UtilityBeltNetworkingTests/Tests/RequestTests.swift
+++ b/Tests/UtilityBeltNetworkingTests/Tests/RequestTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2021 SpotHero, Inc. All rights reserved.
+// Copyright © 2022 SpotHero, Inc. All rights reserved.
 
 import Foundation
 @testable import UtilityBeltNetworking


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/IOS-3809

**Description**
In order to capture difference between errors resulting in the same HTTP Status Code, we need access to the HTTP Response Data to parse it into our internal error object.
This PR adds the response data (if available) in the arguments of `RequestRetrier`.
