### PR TITLE
Add async versions of HTTPClient request methods

### DIFF
--- a/RunScriptHelper.xcodeproj/project.pbxproj
+++ b/RunScriptHelper.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -62,6 +62,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		34E5ABCB24620DE40070A80B /* SwiftLint Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/Sources/UtilityBeltNetworking/HTTPClient+Concurrency.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient+Concurrency.swift
@@ -1,0 +1,86 @@
+// Copyright © 2021 SpotHero, Inc. All rights reserved.
+
+import Foundation
+
+@available(iOS 13.0.0, *)
+public typealias DataTaskSuccess = (request: URLRequest,
+                                    response: HTTPURLResponse,
+                                    data: Data)
+
+@available(iOS 13.0.0, *)
+public typealias DecodableTaskSuccess<T: Decodable> = (request: URLRequest,
+                                                       response: HTTPURLResponse,
+                                                       data: Data,
+                                                       value: T)
+
+@available(iOS 13.0.0, *)
+extension HTTPClient {
+    // MARK: Data Response
+
+    /// Creates and sends a request which fetches raw data from an endpoint.
+    /// - Parameter request: The `URLRequest` to make the request with.
+    /// - Parameter validators: An array of validators that will be applied to the response.
+    /// - Parameter interceptor: An object that can intercept the url request. Defaults to `nil`.
+    /// - Returns: The configured `Request` object that is performed upon execution of this method.
+    public func request(
+        _ urlRequest: URLRequest,
+        validators: [ResponseValidator] = [],
+        interceptor: RequestInterceptor? = nil
+    ) async throws -> DataTaskSuccess {
+        self.logStart(of: urlRequest)
+
+        // Get a modified request with a given timeout interval.
+        let urlRequest = urlRequest.withTimeout(self.timeoutInterval)
+
+        return try await withCheckedThrowingContinuation { [session] continuation in
+            Request(session: session,
+                    validators: validators,
+                    interceptor: interceptor) { response in
+                if let error = response.error {
+                    continuation.resume(throwing: error)
+                } else if let request = response.request,
+                          let httpResponse = response.response,
+                          let data = response.data {
+                    continuation.resume(returning: (request, httpResponse, data))
+                } else {
+                    preconditionFailure("Network request failed with no error")
+                }
+            }.perform(urlRequest: urlRequest)
+        }
+    }
+
+    // MARK: Decodable Object Response
+
+    /// Creates and sends a request which fetches raw data from an endpoint and decodes it.
+    /// - Parameter request: The `URLRequest` to make the request with.
+    /// - Parameter validators: An array of validators that will be applied to the response. Defaults to ensuring a JSON mime type on the response.
+    /// - Parameter interceptor: An object that can intercept the url request. Defaults to `nil`.
+    /// - Parameter decoder: The `JSONDecoder` to use when decoding the response data. Defaults to `JSONDecoder()`.
+    /// - Returns: The configured `Request` object that is performed upon execution of this method.
+    @discardableResult
+    public func request<T: Decodable>(
+        _ urlRequest: URLRequest,
+        validators: [ResponseValidator] = [.ensureMimeType(.json)],
+        interceptor: RequestInterceptor? = nil,
+        decoder: JSONDecoder = .init()
+    ) async throws -> DecodableTaskSuccess<T> {
+        let (request, response, data) = try await request(urlRequest,
+                                                          validators: validators,
+                                                          interceptor: interceptor)
+
+        // If T is Data, we have nothing to decode, so just return it as-is!
+        if let value = data as? T {
+            return (request, response, data, value)
+        }
+
+        // Otherwise decode the data into the requested type
+        do {
+            let decodedObject = try decoder.decode(T.self, from: data)
+            return (request, response, data, decodedObject)
+        } catch let error as DecodingError {
+            throw UBNetworkError.unableToDecode(String(describing: T.self), error)
+        } catch {
+            throw UBNetworkError.unableToDecode(String(describing: T.self), nil)
+        }
+    }
+}

--- a/Sources/UtilityBeltNetworking/HTTPClient+Concurrency.swift
+++ b/Sources/UtilityBeltNetworking/HTTPClient+Concurrency.swift
@@ -2,11 +2,13 @@
 
 import Foundation
 
+/// A tuple returned from requests that return raw data.
 @available(iOS 13.0.0, *)
 public typealias DataTaskSuccess = (request: URLRequest,
                                     response: HTTPURLResponse,
                                     data: Data)
 
+/// A tuple returned from requests that return decoded objects.
 @available(iOS 13.0.0, *)
 public typealias DecodableTaskSuccess<T: Decodable> = (request: URLRequest,
                                                        response: HTTPURLResponse,
@@ -17,11 +19,11 @@ public typealias DecodableTaskSuccess<T: Decodable> = (request: URLRequest,
 extension HTTPClient {
     // MARK: Data Response
 
-    /// Creates and sends a request which fetches raw data from an endpoint.
+    /// Sends a request which fetches raw data from an endpoint.
     /// - Parameter request: The `URLRequest` to make the request with.
     /// - Parameter validators: An array of validators that will be applied to the response.
     /// - Parameter interceptor: An object that can intercept the url request. Defaults to `nil`.
-    /// - Returns: The configured `Request` object that is performed upon execution of this method.
+    /// - Returns: The request used, the response and raw data.
     public func request(
         _ urlRequest: URLRequest,
         validators: [ResponseValidator] = [],
@@ -51,12 +53,12 @@ extension HTTPClient {
 
     // MARK: Decodable Object Response
 
-    /// Creates and sends a request which fetches raw data from an endpoint and decodes it.
+    /// Sends a request which fetches raw data from an endpoint and decodes it.
     /// - Parameter request: The `URLRequest` to make the request with.
     /// - Parameter validators: An array of validators that will be applied to the response. Defaults to ensuring a JSON mime type on the response.
     /// - Parameter interceptor: An object that can intercept the url request. Defaults to `nil`.
     /// - Parameter decoder: The `JSONDecoder` to use when decoding the response data. Defaults to `JSONDecoder()`.
-    /// - Returns: The configured `Request` object that is performed upon execution of this method.
+    /// - Returns: The request used, the response and the raw and decoded data.
     @discardableResult
     public func request<T: Decodable>(
         _ urlRequest: URLRequest,

--- a/Sources/UtilityBeltNetworking/Models/Request.swift
+++ b/Sources/UtilityBeltNetworking/Models/Request.swift
@@ -21,7 +21,7 @@ public final class Request {
     private let completion: DataTaskCompletion?
     
     /// The dispatch queue that the completion will be called on.
-    private let dispatchQueue: DispatchQueue
+    private let dispatchQueue: DispatchQueue?
     
     /// The number of request retries that have been attempted.
     public private(set) var retryCount = 0
@@ -45,7 +45,7 @@ public final class Request {
     
     // MARK: Initialization
     
-    /// Create a new instance of a `Request`.
+    /// Create a new instance of a `Request` that returns on a given dispatch queue.
     /// - Parameters:
     ///   - session: The session in which the request will be made.
     ///   - validators: An array of validators that will be applied to the response. Defaults to an empty array.
@@ -61,6 +61,23 @@ public final class Request {
         self.validators = validators
         self.interceptor = interceptor
         self.dispatchQueue = dispatchQueue
+        self.completion = completion
+    }
+
+    /// Create a new instance of a `Request`.
+    /// - Parameters:
+    ///   - session: The session in which the request will be made.
+    ///   - validators: An array of validators that will be applied to the response. Defaults to an empty array.
+    ///   - interceptor: An object that can intercept the url request. Defaults to `nil`.
+    ///   - completion: The block to call when the request has completed. Defaults to `nil`.
+    public init(session: URLSession,
+                validators: [ResponseValidator] = [],
+                interceptor: RequestInterceptor? = nil,
+                completion: DataTaskCompletion? = nil) {
+        self.session = session
+        self.validators = validators
+        self.interceptor = interceptor
+        self.dispatchQueue = nil
         self.completion = completion
     }
     
@@ -252,9 +269,13 @@ public final class Request {
                                         response: urlResponse,
                                         data: data,
                                         result: result)
-        
-        self.dispatchQueue.async {
-            // Fire the completion!
+
+        // Fire the completion!
+        if let dispatchQueue {
+            dispatchQueue.async {
+                self.completion?(dataResponse)
+            }
+        } else {
             self.completion?(dataResponse)
         }
     }


### PR DESCRIPTION
**Issue Link**
N/A [I'll create one in a minute]

**Description**
Given that clients primarily the request methods, this PR just adds async/await support for them on `HTTPClient`

**Other Notes**
We're using continuations here because the async methods on `URLSession` are only available on iOS 15+. That and rewriting that part of the codebase to use Swift Concurrency is significantly more involved.
