### PR TITLE
Added willStart and didEnd in RequestInterceptor

### DIFF
--- a/Sources/UtilityBeltNetworking/Protocols/RequestInterceptor.swift
+++ b/Sources/UtilityBeltNetworking/Protocols/RequestInterceptor.swift
@@ -2,4 +2,12 @@
 
 import Foundation
 
-public protocol RequestInterceptor: RequestAdapter, RequestRetrier {}
+public protocol RequestInterceptor: RequestAdapter, RequestRetrier {
+    func requestWillStart(_ request: Request)
+    func requestDidEnd(_ request: Request)
+}
+
+extension RequestInterceptor {
+    public func requestWillStart(_ request: Request) {}
+    public func requestDidEnd(_ request: Request) {}
+}


### PR DESCRIPTION
**Issue Link**
N/A

**Description**
We need to add some thread safety in our `AuthenticationInterceptor` and in order to do it properly, I need to know when a request starts and when it ends.